### PR TITLE
Added middleware dict feature - 

### DIFF
--- a/panini/app.py
+++ b/panini/app.py
@@ -3,14 +3,11 @@ import time
 import asyncio
 import uuid
 import logging
-from collections import namedtuple
-from typing import Type
 
 from aiohttp import web
 
-from .middleware import Middleware, middleware_dict_factory
 from .nats_client.nats_client import NATSClient
-from .managers import _EventManager, _TaskManager, _IntervalTaskManager
+from .managers import _EventManager, _TaskManager, _IntervalTaskManager, _MiddlewareManager
 from .http_server.http_server_app import HTTPServer
 from .exceptions import (
     InitializingEventManagerError,
@@ -27,7 +24,7 @@ from .utils import logger
 _app = None
 
 
-class App(_EventManager, _TaskManager, _IntervalTaskManager, NATSClient):
+class App(_EventManager, _TaskManager, _IntervalTaskManager, _MiddlewareManager, NATSClient):
     def __init__(
         self,
         host: str,
@@ -255,19 +252,3 @@ class App(_EventManager, _TaskManager, _IntervalTaskManager, NATSClient):
                     start_thread(task)
             if self.http_server:
                 self.http_server.start_server()
-
-    def add_middleware(self, middleware_cls: Type[Middleware], *args, **kwargs):
-        assert issubclass(middleware_cls, Middleware), "Each custom middleware class must be a subclass of Middleware"
-        MiddlewareTuple = namedtuple("MiddlewareTuple", ["cls", "args", "kwargs"])
-        self.middleware_list.append(MiddlewareTuple(middleware_cls, args, kwargs))
-
-    def get_middleware_dict(self) -> dict:
-        """Get middleware dictionary, that contains next info:
-        {
-            "send_publish_middleware": <list of middleware_func>,
-            "receive_publish_middleware": <list of middleware_func>,
-            "send_request_middleware": <list of middleware_func>,
-            "receive_request_middleware": <list of middleware_func>,
-        }
-        """
-        return middleware_dict_factory(self.middleware_list)

--- a/panini/managers.py
+++ b/panini/managers.py
@@ -22,6 +22,7 @@ class _EventManager:
         self, subject: list or str, validator: type = None, dynamic_subscription=False
     ):
         def wrapper(function):
+            function = _MiddlewareManager._wrap_function_by_middleware(function, "listen")
             function = _EventManager.wrap_function_by_validator(function, validator)
             if type(subject) is list:
                 for t in subject:
@@ -167,8 +168,11 @@ class _MiddlewareManager:
         "listen_request_middleware": [],
     }
 
-    def add_middleware(self, middleware_cls: Type[Middleware], *args, **kwargs):
-        assert issubclass(middleware_cls, Middleware), "Each custom middleware class must be a subclass of Middleware"
+    @staticmethod
+    def add_middleware(middleware_cls: Type[Middleware], *args, **kwargs):
+        assert issubclass(
+            middleware_cls, Middleware
+        ), "Each custom middleware class must be a subclass of Middleware"
         high_priority_functions = (
             "send_publish",
             "listen_publish",
@@ -186,33 +190,122 @@ class _MiddlewareManager:
         middleware_obj = middleware_cls(*args, **kwargs)
         for function_name in high_priority_functions:
             if function_name in middleware_cls.__dict__:
-                self.MIDDLEWARE[f"{function_name}_middleware"].append(
+                _MiddlewareManager.MIDDLEWARE[f"{function_name}_middleware"].append(
                     getattr(middleware_obj, function_name)
                 )
 
         if "send_any" in middleware_cls.__dict__:
             if "send_publish" not in middleware_cls.__dict__:
-                self.MIDDLEWARE[f"send_publish_middleware"].append(
+                _MiddlewareManager.MIDDLEWARE[f"send_publish_middleware"].append(
                     middleware_obj.send_any
                 )
 
             if "send_request" not in middleware_cls.__dict__:
-                self.MIDDLEWARE[f"send_request_middleware"].append(
+                _MiddlewareManager.MIDDLEWARE[f"send_request_middleware"].append(
                     middleware_obj.send_any
                 )
 
         if "listen_any" in middleware_cls.__dict__:
             if "listen_publish" not in middleware_cls.__dict__:
-                self.MIDDLEWARE[f"listen_publish_middleware"].append(
+                _MiddlewareManager.MIDDLEWARE[f"listen_publish_middleware"].append(
                     middleware_obj.listen_any
                 )
 
             if "listen_request" not in middleware_cls.__dict__:
-                self.MIDDLEWARE[f"listen_request_middleware"].append(
+                _MiddlewareManager.MIDDLEWARE[f"listen_request_middleware"].append(
                     middleware_obj.listen_any
                 )
 
     @staticmethod
-    def wrap_function_by_middleware():
-        # TODO: implement wrapping callbacks and functions
-        pass
+    def _wrap_function_by_middleware(
+        function: Callable, function_type: str
+    ) -> Callable:
+        """
+        function: Callable - function to wrap
+        function_type: str - one of the ["listen", "publish", "request"]
+        """
+        assert function_type in (
+            "listen",
+            "publish",
+            "request",
+        ), "function type must be in (`listen`, `publish`, `request`)"
+
+        def wrap_function_by_send_middleware(
+            func: Callable, single_middleware
+        ) -> Callable:
+            def next_wrapper(subject: str, message, **kwargs):
+                return single_middleware(subject, message, func, **kwargs)
+
+            async def aio_next_wrapper(subject: str, message, **kwargs):
+                return await single_middleware(subject, message, func, **kwargs)
+
+            if asyncio.iscoroutinefunction(single_middleware):
+                return aio_next_wrapper
+            else:
+                return next_wrapper
+
+        def wrap_function_by_listen_middleware(
+            func: Callable, single_middleware
+        ) -> Callable:
+            def next_wrapper(msg):
+                return single_middleware(msg, func)
+
+            async def aio_next_wrapper(msg):
+                return await single_middleware(msg, func)
+
+            if asyncio.iscoroutinefunction(single_middleware):
+                return aio_next_wrapper
+            else:
+                return next_wrapper
+
+        def build_middleware_wrapper(
+            func: Callable, middleware_key: str, wrapper: Callable
+        ) -> Callable:
+            for middleware in _MiddlewareManager.MIDDLEWARE[middleware_key]:
+                func = wrapper(func, middleware)
+            return func
+
+        if function_type == "publish":
+            return build_middleware_wrapper(
+                function, "send_publish_middleware", wrap_function_by_send_middleware
+            )
+
+        elif function_type == "request":
+            return build_middleware_wrapper(
+                function, "send_request_middleware", wrap_function_by_send_middleware
+            )
+
+        else:
+            if (
+                len(_MiddlewareManager.MIDDLEWARE["listen_publish_middleware"]) == 0
+                and len(_MiddlewareManager.MIDDLEWARE["listen_request_middleware"]) == 0
+            ):
+                return function
+
+            function_listen_publish = build_middleware_wrapper(
+                function,
+                "listen_publish_middleware",
+                wrap_function_by_listen_middleware,
+            )
+            function_listen_request = build_middleware_wrapper(
+                function,
+                "listen_request_middleware",
+                wrap_function_by_listen_middleware,
+            )
+
+            def listen_wrapper(msg) -> Callable:
+                if msg.reply == "":
+                    return function_listen_publish(msg)
+                else:
+                    return function_listen_request(msg)
+
+            async def aio_listen_wrapper(msg) -> Callable:
+                if msg.reply == "":
+                    return await function_listen_publish(msg)
+                else:
+                    return await function_listen_request(msg)
+
+            if asyncio.iscoroutinefunction(function):
+                return aio_listen_wrapper
+            else:
+                return listen_wrapper

--- a/panini/middleware.py
+++ b/panini/middleware.py
@@ -1,112 +1,52 @@
-from typing import NamedTuple
-
-
 class Middleware:
     def __init__(self, *args, **kwargs):
         pass
 
-    def send_publish(self, msg, publish_func):
+    async def send_publish(self, subject: str, message, publish_func, **kwargs):
         """
-        :param msg: NatsMessage to send
+        :param subject: str
+        :param message: any of supported types
         :param publish_func: Callable for publish
         :return: None
         """
         pass
 
-    def receive_publish(self, msg, callback):
+    async def listen_publish(self, msg, callback):
         """
-        :param msg: NatsMessage to receive
-        :param callback: Callable, that called on receive
+        :param msg: Msg
+        :param callback: Callable, that will be called on receive message
         :return: None
         """
         pass
 
-    def send_request(self, msg, request_func):
+    async def send_request(self, subject: str, message, request_func, **kwargs):
         """
-        :param msg: NatsMessage to send
+        :param subject: str
+        :param message: any of supported types
         :param request_func: Callable for request
-        :return: NatsMessage response
+        :return: any of supported types
         """
         pass
 
-    def receive_request(self, msg, callback):
+    async def listen_request(self, msg, callback):
         """
-        :param msg: NatsMessage to receive
-        :param callback: Callable, that called on receive
-        :return: NatsMessage response
+        :param msg: Msg
+        :param callback: Callable, that will be called on receive message
+        :return: any of supported types
         """
         pass
 
-    def send_any(self, msg, send_func):
+    async def send_any(self, subject: str, message, send_func, **kwargs):
         """
-        :param msg: NatsMessage to send
+        :param subject: str
+        :param message: any of supported types
         :param send_func: Callable for send
-        :return: NatsMessage or None response
+        :return: None or any of supported types
         """
-        pass
 
-    def receive_any(self, msg, callback):
+    async def listen_any(self, msg, callback):
         """
-        :param msg: NatsMessage to receive
-        :param callback: Callable, that called on receive
-        :return: NatsMessage or None response
+        :param msg: Msg
+        :param callback: Callable, that will be called on receive message
+        :return: None or any of supported types
         """
-        pass
-
-
-def middleware_dict_factory(middleware_list: [NamedTuple]) -> dict:
-    """Split middlewares for each specific purpose into middleware dict"""
-    middleware_dict = {
-        "send_publish_middleware": [],
-        "receive_publish_middleware": [],
-        "send_request_middleware": [],
-        "receive_request_middleware": [],
-    }
-    for middleware in middleware_list:
-        assert issubclass(
-            middleware.cls, Middleware
-        ), "Each custom middleware class must be a subclass of Middleware"
-        high_priority_functions = (
-            "send_publish",
-            "receive_publish",
-            "send_request",
-            "receive_request",
-        )
-        global_functions = ("send_any", "receive_any")
-
-        # check, that at least one function is implemented
-        assert any(
-            function in middleware.cls.__dict__
-            for function in high_priority_functions + global_functions
-        ), f"At least one of the following functions must be implemented: {high_priority_functions + global_functions}"
-
-        middleware_obj = middleware.cls(*middleware.args, **middleware.kwargs)
-        for function_name in high_priority_functions:
-            if function_name in middleware.cls.__dict__:
-                middleware_dict[f"{function_name}_middleware"].append(
-                    getattr(middleware_obj, function_name)
-                )
-
-        if "send_any" in middleware.cls.__dict__:
-            if "send_publish" not in middleware.cls.__dict__:
-                middleware_dict[f"send_publish_middleware"].append(
-                    middleware_obj.send_any
-                )
-
-            if "send_request" not in middleware.cls.__dict__:
-                middleware_dict[f"send_request_middleware"].append(
-                    middleware_obj.send_any
-                )
-
-        if "receive_any" in middleware.cls.__dict__:
-            if "receive_publish" not in middleware.cls.__dict__:
-                middleware_dict[f"receive_publish_middleware"].append(
-                    middleware_obj.receive_any
-                )
-
-            if "receive_request" not in middleware.cls.__dict__:
-                middleware_dict[f"receive_request_middleware"].append(
-                    middleware_obj.receive_any
-                )
-
-    return middleware_dict

--- a/panini/middleware.py
+++ b/panini/middleware.py
@@ -1,0 +1,112 @@
+from typing import NamedTuple
+
+
+class Middleware:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def send_publish(self, msg, publish_func):
+        """
+        :param msg: NatsMessage to send
+        :param publish_func: Callable for publish
+        :return: None
+        """
+        pass
+
+    def receive_publish(self, msg, callback):
+        """
+        :param msg: NatsMessage to receive
+        :param callback: Callable, that called on receive
+        :return: None
+        """
+        pass
+
+    def send_request(self, msg, request_func):
+        """
+        :param msg: NatsMessage to send
+        :param request_func: Callable for request
+        :return: NatsMessage response
+        """
+        pass
+
+    def receive_request(self, msg, callback):
+        """
+        :param msg: NatsMessage to receive
+        :param callback: Callable, that called on receive
+        :return: NatsMessage response
+        """
+        pass
+
+    def send_any(self, msg, send_func):
+        """
+        :param msg: NatsMessage to send
+        :param send_func: Callable for send
+        :return: NatsMessage or None response
+        """
+        pass
+
+    def receive_any(self, msg, callback):
+        """
+        :param msg: NatsMessage to receive
+        :param callback: Callable, that called on receive
+        :return: NatsMessage or None response
+        """
+        pass
+
+
+def middleware_dict_factory(middleware_list: [NamedTuple]) -> dict:
+    """Split middlewares for each specific purpose into middleware dict"""
+    middleware_dict = {
+        "send_publish_middleware": [],
+        "receive_publish_middleware": [],
+        "send_request_middleware": [],
+        "receive_request_middleware": [],
+    }
+    for middleware in middleware_list:
+        assert issubclass(
+            middleware.cls, Middleware
+        ), "Each custom middleware class must be a subclass of Middleware"
+        high_priority_functions = (
+            "send_publish",
+            "receive_publish",
+            "send_request",
+            "receive_request",
+        )
+        global_functions = ("send_any", "receive_any")
+
+        # check, that at least one function is implemented
+        assert any(
+            function in middleware.cls.__dict__
+            for function in high_priority_functions + global_functions
+        ), f"At least one of the following functions must be implemented: {high_priority_functions + global_functions}"
+
+        middleware_obj = middleware.cls(*middleware.args, **middleware.kwargs)
+        for function_name in high_priority_functions:
+            if function_name in middleware.cls.__dict__:
+                middleware_dict[f"{function_name}_middleware"].append(
+                    getattr(middleware_obj, function_name)
+                )
+
+        if "send_any" in middleware.cls.__dict__:
+            if "send_publish" not in middleware.cls.__dict__:
+                middleware_dict[f"send_publish_middleware"].append(
+                    middleware_obj.send_any
+                )
+
+            if "send_request" not in middleware.cls.__dict__:
+                middleware_dict[f"send_request_middleware"].append(
+                    middleware_obj.send_any
+                )
+
+        if "receive_any" in middleware.cls.__dict__:
+            if "receive_publish" not in middleware.cls.__dict__:
+                middleware_dict[f"receive_publish_middleware"].append(
+                    middleware_obj.receive_any
+                )
+
+            if "receive_request" not in middleware.cls.__dict__:
+                middleware_dict[f"receive_request_middleware"].append(
+                    middleware_obj.receive_any
+                )
+
+    return middleware_dict

--- a/tests/test_middleware_dict_factory.py
+++ b/tests/test_middleware_dict_factory.py
@@ -1,0 +1,191 @@
+import pytest
+
+from panini import app as panini_app
+from panini.middleware import Middleware
+
+
+class FooMiddleware(Middleware):
+    def send_publish(self, msg, publish_func):
+        """FooMiddleware send_publish"""  # docstring is important for testing
+        pass  # implementation is not important for middleware_dict_factory
+
+    def receive_publish(self, msg, callback):
+        """FooMiddleware receive_publish"""
+        pass
+
+    def receive_request(self, msg, callback):
+        """FooMiddleware receive_request"""
+        pass
+
+
+class BarMiddleware(Middleware):
+    def send_request(self, msg, request_func):
+        """BarMiddleware send_request"""
+        pass
+
+    def receive_publish(self, msg, callback):
+        """BarMiddleware receive_publish"""
+        pass
+
+    def send_any(self, msg, send_func):
+        """BarMiddleware send_any"""
+        pass
+
+    def receive_any(self, msg, callback):
+        """BarMiddleware receive_any"""
+        pass
+
+
+class FooBarMiddleware(Middleware):
+    def __init__(self, foo, bar, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.foo = foo
+        self.bar = bar
+
+    def send_any(self, msg, send_func):
+        return f"""FooBarMiddleware send_any params: {self.foo}, {self.bar}"""  # here implemented for testing
+
+    def receive_request(self, msg, callback):
+        return f"""FooBarMiddleware receive_request params: {self.foo}, {self.bar}"""
+
+
+class IncorrectMiddleware:  # not inherited from Middleware
+    def send_any(self, msg, send_func):
+        pass
+
+
+@pytest.fixture
+def app():
+    return panini_app.App(
+        service_name="test_middleware_dict_factory",
+        host="127.0.0.1",
+        port=4222,
+    )
+
+
+def test_foo_middleware(app):
+    app.add_middleware(FooMiddleware)
+    middleware_dict = app.get_middleware_dict()
+    assert len(middleware_dict["send_publish_middleware"]) == 1
+    assert len(middleware_dict["send_request_middleware"]) == 0
+    assert len(middleware_dict["receive_publish_middleware"]) == 1
+    assert len(middleware_dict["receive_request_middleware"]) == 1
+
+    assert (
+        middleware_dict["send_publish_middleware"][0].__doc__
+        == "FooMiddleware send_publish"
+    )
+    assert (
+        middleware_dict["receive_publish_middleware"][0].__doc__
+        == "FooMiddleware receive_publish"
+    )
+    assert (
+        middleware_dict["receive_request_middleware"][0].__doc__
+        == "FooMiddleware receive_request"
+    )
+
+
+def test_bar_middleware(app):
+    app.add_middleware(BarMiddleware)
+    middleware_dict = app.get_middleware_dict()
+
+    assert len(middleware_dict["send_publish_middleware"]) == 1
+    assert len(middleware_dict["send_request_middleware"]) == 1
+    assert len(middleware_dict["receive_publish_middleware"]) == 1
+    assert len(middleware_dict["receive_request_middleware"]) == 1
+
+    assert (
+        middleware_dict["send_publish_middleware"][0].__doc__
+        == "BarMiddleware send_any"
+    )
+    assert (
+        middleware_dict["send_request_middleware"][0].__doc__
+        == "BarMiddleware send_request"
+    )
+    assert (
+        middleware_dict["receive_publish_middleware"][0].__doc__
+        == "BarMiddleware receive_publish"
+    )
+    assert (
+        middleware_dict["receive_request_middleware"][0].__doc__
+        == "BarMiddleware receive_any"
+    )
+
+
+def test_foo_bar_middleware(app):
+    app.add_middleware(FooBarMiddleware, "foo", bar="bar")
+    middleware_dict = app.get_middleware_dict()
+    assert len(middleware_dict["send_publish_middleware"]) == 1
+    assert len(middleware_dict["send_request_middleware"]) == 1
+    assert len(middleware_dict["receive_publish_middleware"]) == 0
+    assert len(middleware_dict["receive_request_middleware"]) == 1
+
+    assert (
+        middleware_dict["send_publish_middleware"][0](None, None)
+        == "FooBarMiddleware send_any params: foo, bar"
+    )
+    assert (
+        middleware_dict["send_request_middleware"][0](None, None)
+        == "FooBarMiddleware send_any params: foo, bar"
+    )
+    assert (
+        middleware_dict["receive_request_middleware"][0](None, None)
+        == "FooBarMiddleware receive_request "
+        "params: foo, bar"
+    )
+
+
+def test_multiple_middlewares_order(app):
+    app.add_middleware(FooMiddleware)
+    app.add_middleware(BarMiddleware)
+    app.add_middleware(FooBarMiddleware, "foo", bar="bar")
+    middleware_dict = app.get_middleware_dict()
+    assert len(middleware_dict["send_publish_middleware"]) == 3
+    assert len(middleware_dict["send_request_middleware"]) == 2
+    assert len(middleware_dict["receive_publish_middleware"]) == 2
+    assert len(middleware_dict["receive_request_middleware"]) == 3
+
+    assert middleware_dict["send_publish_middleware"][0].__doc__.startswith(
+        "FooMiddleware"
+    )
+    assert middleware_dict["send_publish_middleware"][1].__doc__.startswith(
+        "BarMiddleware"
+    )
+    assert middleware_dict["send_publish_middleware"][2](None, None).startswith(
+        "FooBarMiddleware"
+    )
+
+    assert middleware_dict["send_request_middleware"][0].__doc__.startswith(
+        "BarMiddleware"
+    )
+    assert middleware_dict["send_request_middleware"][1](None, None).startswith(
+        "FooBarMiddleware"
+    )
+
+    assert middleware_dict["receive_publish_middleware"][0].__doc__.startswith(
+        "FooMiddleware"
+    )
+    assert middleware_dict["receive_publish_middleware"][1].__doc__.startswith(
+        "BarMiddleware"
+    )
+
+    assert middleware_dict["receive_request_middleware"][0].__doc__.startswith(
+        "FooMiddleware"
+    )
+    assert middleware_dict["receive_request_middleware"][1].__doc__.startswith(
+        "BarMiddleware"
+    )
+    assert middleware_dict["receive_request_middleware"][2](None, None).startswith(
+        "FooBarMiddleware"
+    )
+
+
+def test_incorrect_middlewares(app):
+    with pytest.raises(AssertionError):
+        app.add_middleware(IncorrectMiddleware)
+
+    with pytest.raises(TypeError):
+        app.add_middleware(
+            FooBarMiddleware
+        )  # not enough parameters for FooBarMiddleware __init__() method
+        app.get_middleware_dict()

--- a/tests/test_middleware_manager.py
+++ b/tests/test_middleware_manager.py
@@ -1,13 +1,16 @@
+import asyncio
+
 import pytest
 
 from panini import app as panini_app
+from panini.managers import _MiddlewareManager
 from panini.middleware import Middleware
 
 
 class FooMiddleware(Middleware):
     async def send_publish(self, subject: str, message, publish_func, **kwargs):
         """FooMiddleware send_publish"""  # docstring is important for testing
-        pass  # implementation is not important for middleware_dict_factory
+        pass  # implementation is not important for some of these tests
 
     async def listen_publish(self, msg, callback):
         """FooMiddleware listen_publish"""
@@ -54,6 +57,34 @@ class IncorrectMiddleware:  # not inherited from Middleware
         pass
 
 
+class IncSyncMiddleware(Middleware):
+    def send_any(self, subject: str, message, send_func, **kwargs):
+        message["data"] += 1
+        send_func(subject, message, **kwargs)
+        message["data"] += 3
+
+
+class DecSyncMiddleware(Middleware):
+    def listen_any(self, msg, callback):
+        msg.data -= 1
+        callback(msg)
+        msg.data -= 3
+
+
+class IncMiddleware(Middleware):
+    async def send_any(self, subject: str, message, send_func, **kwargs):
+        message["data"] += 1
+        await send_func(subject, message, **kwargs)
+        message["data"] += 3
+
+
+class DecMiddleware(Middleware):
+    async def listen_any(self, msg, callback):
+        msg.data -= 1
+        await callback(msg)
+        msg.data -= 3
+
+
 @pytest.fixture
 def app():
     app = panini_app.App(
@@ -61,7 +92,7 @@ def app():
         host="127.0.0.1",
         port=4222,
     )
-    app.MIDDLEWARE = {
+    _MiddlewareManager.MIDDLEWARE = {
         "send_publish_middleware": [],
         "listen_publish_middleware": [],
         "send_request_middleware": [],
@@ -72,7 +103,7 @@ def app():
 
 def test_foo_middleware(app):
     app.add_middleware(FooMiddleware)
-    middleware_dict = app.MIDDLEWARE
+    middleware_dict = _MiddlewareManager.MIDDLEWARE
     assert len(middleware_dict["send_publish_middleware"]) == 1
     assert len(middleware_dict["send_request_middleware"]) == 0
     assert len(middleware_dict["listen_publish_middleware"]) == 1
@@ -94,7 +125,7 @@ def test_foo_middleware(app):
 
 def test_bar_middleware(app):
     app.add_middleware(BarMiddleware)
-    middleware_dict = app.MIDDLEWARE
+    middleware_dict = _MiddlewareManager.MIDDLEWARE
 
     assert len(middleware_dict["send_publish_middleware"]) == 1
     assert len(middleware_dict["send_request_middleware"]) == 1
@@ -121,7 +152,7 @@ def test_bar_middleware(app):
 
 def test_foo_bar_middleware(app):
     app.add_middleware(FooBarMiddleware, "foo", bar="bar")
-    middleware_dict = app.MIDDLEWARE
+    middleware_dict = _MiddlewareManager.MIDDLEWARE
     assert len(middleware_dict["send_publish_middleware"]) == 1
     assert len(middleware_dict["send_request_middleware"]) == 1
     assert len(middleware_dict["listen_publish_middleware"]) == 0
@@ -146,7 +177,7 @@ def test_multiple_middlewares_order(app):
     app.add_middleware(FooMiddleware)
     app.add_middleware(BarMiddleware)
     app.add_middleware(FooBarMiddleware, "foo", bar="bar")
-    middleware_dict = app.MIDDLEWARE
+    middleware_dict = _MiddlewareManager.MIDDLEWARE
     assert len(middleware_dict["send_publish_middleware"]) == 3
     assert len(middleware_dict["send_request_middleware"]) == 2
     assert len(middleware_dict["listen_publish_middleware"]) == 2
@@ -195,3 +226,127 @@ def test_incorrect_middlewares(app):
         app.add_middleware(
             FooBarMiddleware
         )  # not enough parameters for FooBarMiddleware __init__() method
+
+
+def test_wrap_function_by_middleware_inc_sync(app):
+    def foo(subject, message, **kwargs):
+        assert message["data"] == 2
+        message["data"] += 2
+
+    app.add_middleware(IncSyncMiddleware)
+    for send in ("publish", "request"):
+        wrapped_function = app._wrap_function_by_middleware(foo, send)
+        temp_message = {"data": 1}
+        wrapped_function("", temp_message)
+        assert temp_message["data"] == 7
+
+
+def test_wrap_function_by_middleware_dec_sync(app):
+    class Bar:
+        data = 5
+        reply = ""
+
+    def bar(msg):
+        assert msg.data == 4
+        msg.data -= 2
+
+    app.add_middleware(DecSyncMiddleware)
+    wrapped_function = app._wrap_function_by_middleware(bar, "listen")
+    temp_message = Bar()
+    wrapped_function(temp_message)
+    assert temp_message.data == -1
+
+
+def test_wrap_function_by_middleware_inc(app):
+    async def foo(subject, message, **kwargs):
+        assert message["data"] == 2
+        message["data"] += 2
+
+    app.add_middleware(IncMiddleware)
+    loop = asyncio.get_event_loop()
+
+    for send in ("publish", "request"):
+        wrapped_function = app._wrap_function_by_middleware(foo, send)
+        temp_message = {"data": 1}
+        loop.run_until_complete(wrapped_function("", temp_message))
+        assert temp_message["data"] == 7
+
+
+def test_wrap_function_by_middleware_dec(app):
+    class Bar:
+        data = 5
+        reply = ""
+
+    async def bar(msg):
+        assert msg.data == 4
+        msg.data -= 2
+
+    loop = asyncio.get_event_loop()
+
+    app.add_middleware(DecMiddleware)
+    wrapped_function = app._wrap_function_by_middleware(bar, "listen")
+    temp_message = Bar()
+    loop.run_until_complete(wrapped_function(temp_message))
+    assert temp_message.data == -1
+
+
+def test_wrap_function_by_middleware_inc_dec_sync(app):
+    class Bar:
+        data = 5
+        reply = "someone"
+
+    def foo(subject, message, **kwargs):
+        assert message["data"] == 3
+        message["data"] += 2
+
+    def bar(msg):
+        assert msg.data == 3
+        msg.data -= 2
+
+    app.add_middleware(IncSyncMiddleware)
+    app.add_middleware(IncSyncMiddleware)
+    app.add_middleware(DecSyncMiddleware)
+    app.add_middleware(DecSyncMiddleware)
+
+    for send in ("publish", "request"):
+        wrapped_function = app._wrap_function_by_middleware(foo, send)
+        temp_message = {"data": 1}
+        wrapped_function("", temp_message)
+        assert temp_message["data"] == 11
+
+    wrapped_function = app._wrap_function_by_middleware(bar, "listen")
+    temp_message = Bar()
+    wrapped_function(temp_message)
+    assert temp_message.data == -5
+
+
+def test_wrap_function_by_middleware_inc_dec(app):
+    class Bar:
+        data = 5
+        reply = "someone"
+
+    async def foo(subject, message, **kwargs):
+        assert message["data"] == 3
+        message["data"] += 2
+
+    async def bar(msg):
+        assert msg.data == 3
+        msg.data -= 2
+
+    app.add_middleware(IncMiddleware)
+    app.add_middleware(IncMiddleware)
+    app.add_middleware(DecMiddleware)
+    app.add_middleware(DecMiddleware)
+
+    loop = asyncio.get_event_loop()
+
+    for send in ("publish", "request"):
+        wrapped_function = app._wrap_function_by_middleware(foo, send)
+        temp_message = {"data": 1}
+        loop.run_until_complete(wrapped_function("", temp_message))
+        assert temp_message["data"] == 11
+
+    wrapped_function = app._wrap_function_by_middleware(bar, "listen")
+    temp_message = Bar()
+    loop.run_until_complete(wrapped_function(temp_message))
+    assert temp_message.data == -5


### PR DESCRIPTION
Middleware interface and splitting for specific functionality
{
    "send_publish_middleware": <list of middleware_func>,
    "listen_publish_middleware": <list of middleware_func>,
    "send_request_middleware": <list of middleware_func>,
    "listen_request_middleware": <list of middleware_func>,
}