### PR TITLE
Bug/naming fixes

### DIFF
--- a/examples/simple_examples/_wss_manager.py
+++ b/examples/simple_examples/_wss_manager.py
@@ -65,7 +65,7 @@ class WSSManager:
                 if action == "subscribe":
                     for subject in subjects:
                         cb = await self._get_callback(client_ws_connection)
-                        ssid = await self.app.aio_subscribe_new_subject(subject, cb)
+                        ssid = await self.app.subscribe_new_subject(subject, cb)
                         if subject not in self.ssid_map:
                             self.ssid_map[subject] = []
                         self.ssid_map[subject].append(ssid)
@@ -81,7 +81,7 @@ class WSSManager:
                     for subject in subjects:
                         if subject in self.ssid_map:
                             for ssid in self.ssid_map[subject]:
-                                await self.app.aio_unsubscribe_ssid(ssid)
+                                await self.app.unsubscribe_ssid(ssid)
                             await client_ws_connection.send_str(
                                 json.dumps(
                                     {

--- a/panini/app.py
+++ b/panini/app.py
@@ -42,7 +42,6 @@ class App(
         reconnect: bool = False,
         max_reconnect_attempts: int = 60,
         reconnecting_time_sleep: int = 2,
-        app_strategy: str = "asyncio",
         subscribe_subjects_and_callbacks: dict = None,
         allocation_queue_group: str = "",
         listen_subject_only_if_include: list = None,
@@ -63,7 +62,6 @@ class App(
         :param reconnect: allows reconnect if connection to NATS has been lost
         :param max_reconnect_attempts: number of reconnect attempts
         :param reconnecting_time_sleep: pause between reconnection
-        :param app_strategy:  'asyncio' only - but we let it with warning for backward parameter support
         :param subscribe_subjects_and_callbacks: if you need to subscribe additional
                                         subjects(except subjects from event.py).
                                         This way doesn't support validators
@@ -91,7 +89,6 @@ class App(
             os.environ["CLIENT_ID"] = client_id
             self.client_id = client_id
             self.service_name = service_name
-            self.app_strategy = app_strategy
             self.nats_config = {
                 "host": host,
                 "port": port,
@@ -131,10 +128,6 @@ class App(
                     self.client_id,
                 )
 
-            if app_strategy != "asyncio":
-                self.logger.warning(
-                    "Only 'asyncio' strategy is now supported. The app will run in asyncio mode!"
-                )
             self.logger_process = None
             self.log_stop_event = None
             self.log_listener_queue = None
@@ -239,15 +232,13 @@ class App(
         tasks = asyncio.all_tasks(loop)
         for coro in self.tasks:
             if not asyncio.iscoroutinefunction(coro):
-                raise InitializingTaskError(
-                    "For asyncio app_strategy only coroutine tasks allowed"
-                )
+                raise InitializingTaskError("Only coroutine tasks allowed")
             loop.create_task(coro())
         for interval in self.interval_tasks:
             for coro in self.interval_tasks[interval]:
                 if not asyncio.iscoroutinefunction(coro):
                     raise InitializingIntervalTaskError(
-                        "For asyncio app_strategy only coroutine interval tasks allowed"
+                        "Only coroutine interval tasks allowed"
                     )
                 loop.create_task(coro())
         if self.http_server:

--- a/panini/managers.py
+++ b/panini/managers.py
@@ -50,7 +50,7 @@ class _EventManager:
             raise NotReadyError(
                 "Something wrong. NATS client should be connected first"
             )
-        self.subscribe_new_subject(subject, function)
+        self.subscribe_new_subject_sync(subject, function)
 
     @staticmethod
     def wrap_function_by_validator(function, validator):
@@ -239,13 +239,13 @@ class _MiddlewareManager:
                 def next_wrapper(subject: str, message, *args, **kwargs):
                     return single_middleware(subject, message, func, *args, **kwargs)
 
-                async def aio_next_wrapper(subject: str, message, *args, **kwargs):
+                async def async_next_wrapper(subject: str, message, *args, **kwargs):
                     return await single_middleware(
                         subject, message, func, *args, **kwargs
                     )
 
                 if asyncio.iscoroutinefunction(single_middleware):
-                    return aio_next_wrapper
+                    return async_next_wrapper
                 else:
                     return next_wrapper
 
@@ -255,11 +255,11 @@ class _MiddlewareManager:
                 def next_wrapper(msg):
                     return single_middleware(msg, func)
 
-                async def aio_next_wrapper(msg):
+                async def async_next_wrapper(msg):
                     return await single_middleware(msg, func)
 
                 if asyncio.iscoroutinefunction(single_middleware):
-                    return aio_next_wrapper
+                    return async_next_wrapper
                 else:
                     return next_wrapper
 
@@ -309,14 +309,14 @@ class _MiddlewareManager:
                     else:
                         return function_listen_request(msg)
 
-                async def aio_listen_wrapper(msg) -> Callable:
+                async def async_listen_wrapper(msg) -> Callable:
                     if msg.reply == "":
                         return await function_listen_publish(msg)
                     else:
                         return await function_listen_request(msg)
 
                 if asyncio.iscoroutinefunction(function):
-                    return aio_listen_wrapper
+                    return async_listen_wrapper
                 else:
                     return listen_wrapper
 

--- a/panini/nats_client.py
+++ b/panini/nats_client.py
@@ -104,14 +104,14 @@ class NATSClient:
             listen_subjects_callbacks = self.listen_subjects_callbacks
             for subject, callbacks in listen_subjects_callbacks.items():
                 for callback in callbacks:
-                    await self.aio_subscribe_new_subject(
+                    await self.subscribe_new_subject(
                         subject, callback, init_subscription=True
                     )
 
-    def subscribe_new_subject(self, subject: str, callback: CoroutineType):
-        self.loop.run_until_complete(self.aio_subscribe_new_subject(subject, callback))
+    def subscribe_new_subject_sync(self, subject: str, callback: CoroutineType):
+        self.loop.run_until_complete(self.subscribe_new_subject(subject, callback))
 
-    async def aio_subscribe_new_subject(
+    async def subscribe_new_subject(
         self, subject: str, callback: CoroutineType, init_subscription=False
     ):
         callback = _MiddlewareManager._wrap_function_by_middleware("listen")(callback)
@@ -131,10 +131,10 @@ class NATSClient:
             self.listen_subjects_callbacks[subject].append(callback)
         return ssid
 
-    def unsubscribe_subject(self, subject: str):
-        self.loop.run_until_complete(self.aio_unsubscribe_subject(subject))
+    def unsubscribe_subject_sync(self, subject: str):
+        self.loop.run_until_complete(self.unsubscribe_subject(subject))
 
-    async def aio_unsubscribe_subject(self, subject: str):
+    async def unsubscribe_subject(self, subject: str):
         if subject not in self.ssid_map:
             raise Exception(f"Subject {subject} hasn't been subscribed")
         for ssid in self.ssid_map[subject]:
@@ -142,10 +142,10 @@ class NATSClient:
         del self.ssid_map[subject]
         del self.listen_subjects_callbacks[subject]
 
-    def unsubscribe_ssid(self, ssid: int, subject: str = None):
-        self.loop.run_until_complete(self.aio_unsubscribe_ssid(ssid, subject))
+    def unsubscribe_ssid_sync(self, ssid: int, subject: str = None):
+        self.loop.run_until_complete(self.unsubscribe_ssid(ssid, subject))
 
-    async def aio_unsubscribe_ssid(self, ssid: int, subject: str = None):
+    async def unsubscribe_ssid(self, ssid: int, subject: str = None):
         if subject and subject not in self.ssid_map:
             raise Exception(f"Subject {subject} hasn't been subscribed")
         await self.client.unsubscribe(ssid)
@@ -269,10 +269,10 @@ class NATSClient:
             response = response.decode()
         return response
 
-    def disconnect(self):
-        self.loop.run_until_complete(self.aio_disconnect())
+    def disconnect_sync(self):
+        self.loop.run_until_complete(self.disconnect())
 
-    async def aio_disconnect(self):
+    async def disconnect(self):
         await self.client.drain()
         self.log.warning("Disconnected")
 

--- a/panini/utils/logger.py
+++ b/panini/utils/logger.py
@@ -12,7 +12,7 @@ from ..utils import helper
 
 
 # Decorator for check, if logger exist
-def check_logger(func):
+def check_logger_connected(func):
     def wrapper(self, msg, **extra):
         if self.logger is None:
             raise Exception("Logger hasn't been connected")
@@ -30,23 +30,23 @@ class Logger:
     def __init__(self, logger: logging.Logger):
         self.logger = logger
 
-    @check_logger
+    @check_logger_connected
     def debug(self, msg, **extra):
         self.logger.debug(msg, extra={"extra": extra})
 
-    @check_logger
+    @check_logger_connected
     def info(self, msg, **extra):
         self.logger.info(msg, extra={"extra": extra})
 
-    @check_logger
+    @check_logger_connected
     def warning(self, msg, **extra):
         self.logger.warning(msg, extra={"extra": extra})
 
-    @check_logger
+    @check_logger_connected
     def error(self, msg, **extra):
         self.logger.error(msg, extra={"extra": extra})
 
-    @check_logger
+    @check_logger_connected
     def exception(self, msg, **extra):
         self.logger.exception(msg, extra={"extra": extra})
 


### PR DESCRIPTION
Some little fixes in interface:
- removed `aio` from all nats_client methods (now `sync` suffix for sync method)
- removed `app_strategy` parameter