### PR TITLE
#165 - added non-blocking request support for bytes messages

### DIFF
--- a/examples/simple_examples/async_non_blocking_request.py
+++ b/examples/simple_examples/async_non_blocking_request.py
@@ -1,0 +1,63 @@
+import asyncio
+import time
+from panini import app as panini_app
+
+app = panini_app.App(
+    service_name="async_sender",
+    host="127.0.0.1",
+    port=4222,
+)
+log = app.logger
+
+started_time = None
+msg_num = 10
+current_msg_num = 0
+
+msg = {
+    "key1": "value1",
+    "key2": 2,
+    "key3": 3.0,
+    "key4": [1, 2, 3, 4],
+    "key5": {"1": 1, "2": 2, "3": 3, "4": 4, "5": 5},
+    "key6": {"subkey1": "1", "subkey2": 2, "3": 3, "4": 4, "5": 5},
+    "key7": None,
+}
+
+
+@app.task()
+async def request_to_another_topic():
+    global started_time
+    started_time = time.monotonic()
+
+    def handle_response(msg):
+        """Note, that here msg.data will be in bytes"""
+        global current_msg_num
+        current_msg_num += 1
+        log.info(f"MSG: data: {msg.data}, data type: {type(msg.data)}")
+        log.info(f"<<<= response num {current_msg_num}")
+
+    for _ in range(msg_num):
+        await app.request(
+            message=msg, subject="some.topic.to.request", callback=handle_response
+        )
+        log.info(f"=>>> request num {_}")
+    print(f"Sent requests duration = {time.monotonic() - started_time}")
+    await app.publish(message={}, subject="finalize.it")
+
+
+@app.listen("some.topic.to.request")
+async def subject_for_requests_listener(msg):
+    await asyncio.sleep(1)
+    return {"success": True, "data": "request has been processed"}
+
+
+@app.listen("finalize.it")
+async def finalizer(msg):
+    while int(current_msg_num) < int(msg_num):
+        await asyncio.sleep(0.005)
+    duration = time.monotonic() - started_time
+    print(f"Handling {msg_num} requests  took: {duration} sec")
+
+
+if __name__ == "__main__":
+    app.start()

--- a/panini/nats_client.py
+++ b/panini/nats_client.py
@@ -1,3 +1,4 @@
+import typing
 import ujson
 import asyncio
 import threading
@@ -179,10 +180,11 @@ class NATSClient:
         message,
         timeout: int = 10,
         data_type: type or str = "json.dumps",
+        callback: typing.Callable = None,
     ):
         # asyncio.ensure_future(self.request(subject, message, timeout, data_type))
         return self.loop.run_until_complete(
-            self.request(subject, message, timeout, data_type)
+            self.request(subject, message, timeout, data_type, callback)
         )
 
     def request_from_another_thread_sync(
@@ -273,8 +275,11 @@ class NATSClient:
         message,
         timeout: int = 10,
         data_type: type or str = "json.dumps",
+        callback: typing.Callable = None,
     ):
         message = self.format_message_data_type(message, data_type)
+        if callback is not None:
+            return await self.client.request(subject, message, cb=callback)
         response = await self.client.request(subject, message, timeout=timeout)
         response = response.data
         if data_type == "json.dumps":
@@ -289,9 +294,14 @@ class NATSClient:
         message,
         timeout: int = 10,
         data_type: type or str = "json.dumps",
+        callback: typing.Callable = None,
     ):
         return await self._request_wrapped(
-            subject=subject, message=message, timeout=timeout, data_type=data_type
+            subject=subject,
+            message=message,
+            timeout=timeout,
+            data_type=data_type,
+            callback=callback,
         )
 
     def disconnect_sync(self):

--- a/tests/test_non_blocking_request.py
+++ b/tests/test_non_blocking_request.py
@@ -1,0 +1,68 @@
+import asyncio
+
+import pytest
+
+from panini.test_client import TestClient
+from panini import app as panini_app
+
+msg_num = 10
+
+
+def run_panini():
+    app = panini_app.App(
+        service_name="test_non_blocking_request",
+        host="127.0.0.1",
+        port=4222,
+        logger_in_separate_process=False,
+    )
+
+    @app.listen("test_non_blocking_request.start")
+    async def non_blocking_requests(msg):
+        def handle_response(msg):
+            app.publish_sync(
+                "test_non_blocking_request.finalize",
+                {"success": True, "data_type": type(msg.data).__name__},
+            )
+
+        for _ in range(msg_num):
+            await app.request(
+                subject="test_non_blocking_request.foo",
+                message={"data": 1},
+                callback=handle_response,
+            )
+
+        return {"success": True}
+
+    @app.listen("test_non_blocking_request.foo")
+    async def subject_for_requests_listener(msg):
+        await asyncio.sleep(0.5)
+        return {"success": True, "data": "request has been processed"}
+
+    app.start()
+
+
+result = None
+
+
+@pytest.fixture(scope="module")
+def client():
+    client = TestClient(run_panini, socket_timeout=100)
+
+    @client.listen("test_non_blocking_request.finalize")
+    def helper(msg):
+        global result
+        result = msg.data
+
+    client.start(do_always_listen=False)
+    yield client
+    client.stop()
+
+
+def test_non_blocking_request(client):
+    response = client.request("test_non_blocking_request.start", {})
+    assert response["success"] is True
+
+    client.wait(msg_num)
+    assert isinstance(result, dict)
+    assert result["success"] is True
+    assert result["data_type"] == "bytes"


### PR DESCRIPTION
For now only works for bytes, and will assume, that send middlewares do not work with `response`