### PR TITLE
v0.3.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,31 +1,69 @@
 version: 2.1
-jobs:
-  test:
-    machine:
-      image: ubuntu-2004:202010-01
-      docker_layer_caching: true
-    working_directory: ~/panini/
+parameters:
+  repo:
+    type: string
+    default: "panini"
+
+executors:
+  executor-for-panini:
+    parameters:
+      version:
+        type: string
+        default: "3.8"
+    docker:
+      - image: python:<< parameters.version >>-slim-buster
+      - image: nats
+
+commands:
+  install-requirements:
     steps:
-      - checkout
       - run:
-          name: Installing libraries
-          command: |
-            pip3 install pytest
-            pip3 install -r requirements/defaults.txt
+          name: Install requirements
+          command: pip3 install pytest && pip3 install -r requirements/defaults.txt
+  run-tests:
+    steps:
       - run:
-          name: Start containers nats
+          name: Run tests
           command: |
-            docker run -d -p 4222:4222 -p 6222:6222 -p 8222:8222 nats
-      - run:
-          name: Run Tests
-          command: |
-            cd ~/panini
             mkdir results
             timeout 300 python3 -m pytest --junitxml=results/out.xml || (echo "Doesn't finished succefully" && exit 1)
+  store-results:
+    steps:
       - store_test_results:
           path: results
-    path:
+
+working_directory: ~/<< pipeline.parameters.repo >>
+
+jobs:
+  test:
+    parameters:
+      version:
+        description: "python version tag"
+        default: "3.8"
+        type: string
+    executor:
+      name: executor-for-panini
+      version: <<parameters.version>>
+    steps:
+      - checkout
+      - when:
+          condition: 
+            matches: { pattern: "3.10.*", value: <<parameters.version>> }
+          steps:
+            - run: 
+                command: |
+                  apt update && apt install -y libc6-dev gcc build-essential
+                  sed -i 's/1.6.1/1.6.3/' requirements/defaults.txt
+      - install-requirements
+      - run-tests
+      - store-results
 workflows:
   main:
     jobs:
-      - test
+      - test:
+          matrix:
+            parameters:
+              version:
+                - "3.8"
+                - "3.9"
+#                - "3.10.0b1"

--- a/examples/simple_examples/_wss_manager.py
+++ b/examples/simple_examples/_wss_manager.py
@@ -65,7 +65,7 @@ class WSSManager:
                 if action == "subscribe":
                     for subject in subjects:
                         cb = await self._get_callback(client_ws_connection)
-                        ssid = await self.app.aio_subscribe_new_subject(subject, cb)
+                        ssid = await self.app.subscribe_new_subject(subject, cb)
                         if subject not in self.ssid_map:
                             self.ssid_map[subject] = []
                         self.ssid_map[subject].append(ssid)
@@ -81,7 +81,7 @@ class WSSManager:
                     for subject in subjects:
                         if subject in self.ssid_map:
                             for ssid in self.ssid_map[subject]:
-                                await self.app.aio_unsubscribe_ssid(ssid)
+                                await self.app.unsubscribe_ssid(ssid)
                             await client_ws_connection.send_str(
                                 json.dumps(
                                     {

--- a/examples/simple_examples/async_non_blocking_request.py
+++ b/examples/simple_examples/async_non_blocking_request.py
@@ -1,0 +1,63 @@
+import asyncio
+import time
+from panini import app as panini_app
+
+app = panini_app.App(
+    service_name="async_sender",
+    host="127.0.0.1",
+    port=4222,
+)
+log = app.logger
+
+started_time = None
+msg_num = 10
+current_msg_num = 0
+
+msg = {
+    "key1": "value1",
+    "key2": 2,
+    "key3": 3.0,
+    "key4": [1, 2, 3, 4],
+    "key5": {"1": 1, "2": 2, "3": 3, "4": 4, "5": 5},
+    "key6": {"subkey1": "1", "subkey2": 2, "3": 3, "4": 4, "5": 5},
+    "key7": None,
+}
+
+
+@app.task()
+async def request_to_another_topic():
+    global started_time
+    started_time = time.monotonic()
+
+    def handle_response(msg):
+        """Note, that here msg.data will be in bytes"""
+        global current_msg_num
+        current_msg_num += 1
+        log.info(f"MSG: data: {msg.data}, data type: {type(msg.data)}")
+        log.info(f"<<<= response num {current_msg_num}")
+
+    for _ in range(msg_num):
+        await app.request(
+            message=msg, subject="some.topic.to.request", callback=handle_response
+        )
+        log.info(f"=>>> request num {_}")
+    print(f"Sent requests duration = {time.monotonic() - started_time}")
+    await app.publish(message={}, subject="finalize.it")
+
+
+@app.listen("some.topic.to.request")
+async def subject_for_requests_listener(msg):
+    await asyncio.sleep(1)
+    return {"success": True, "data": "request has been processed"}
+
+
+@app.listen("finalize.it")
+async def finalizer(msg):
+    while int(current_msg_num) < int(msg_num):
+        await asyncio.sleep(0.005)
+    duration = time.monotonic() - started_time
+    print(f"Handling {msg_num} requests  took: {duration} sec")
+
+
+if __name__ == "__main__":
+    app.start()

--- a/panini/app.py
+++ b/panini/app.py
@@ -42,7 +42,6 @@ class App(
         reconnect: bool = False,
         max_reconnect_attempts: int = 60,
         reconnecting_time_sleep: int = 2,
-        app_strategy: str = "asyncio",
         subscribe_subjects_and_callbacks: dict = None,
         allocation_queue_group: str = "",
         listen_subject_only_if_include: list = None,
@@ -63,7 +62,6 @@ class App(
         :param reconnect: allows reconnect if connection to NATS has been lost
         :param max_reconnect_attempts: number of reconnect attempts
         :param reconnecting_time_sleep: pause between reconnection
-        :param app_strategy:  'asyncio' only - but we let it with warning for backward parameter support
         :param subscribe_subjects_and_callbacks: if you need to subscribe additional
                                         subjects(except subjects from event.py).
                                         This way doesn't support validators
@@ -91,7 +89,6 @@ class App(
             os.environ["CLIENT_ID"] = client_id
             self.client_id = client_id
             self.service_name = service_name
-            self.app_strategy = app_strategy
             self.nats_config = {
                 "host": host,
                 "port": port,
@@ -131,10 +128,6 @@ class App(
                     self.client_id,
                 )
 
-            if app_strategy != "asyncio":
-                self.logger.warning(
-                    "Only 'asyncio' strategy is now supported. The app will run in asyncio mode!"
-                )
             self.logger_process = None
             self.log_stop_event = None
             self.log_listener_queue = None
@@ -239,15 +232,13 @@ class App(
         tasks = asyncio.all_tasks(loop)
         for coro in self.tasks:
             if not asyncio.iscoroutinefunction(coro):
-                raise InitializingTaskError(
-                    "For asyncio app_strategy only coroutine tasks allowed"
-                )
+                raise InitializingTaskError("Only coroutine tasks allowed")
             loop.create_task(coro())
         for interval in self.interval_tasks:
             for coro in self.interval_tasks[interval]:
                 if not asyncio.iscoroutinefunction(coro):
                     raise InitializingIntervalTaskError(
-                        "For asyncio app_strategy only coroutine interval tasks allowed"
+                        "Only coroutine interval tasks allowed"
                     )
                 loop.create_task(coro())
         if self.http_server:

--- a/panini/managers.py
+++ b/panini/managers.py
@@ -50,7 +50,7 @@ class _EventManager:
             raise NotReadyError(
                 "Something wrong. NATS client should be connected first"
             )
-        self.subscribe_new_subject(subject, function)
+        self.subscribe_new_subject_sync(subject, function)
 
     @staticmethod
     def wrap_function_by_validator(function, validator):
@@ -239,13 +239,13 @@ class _MiddlewareManager:
                 def next_wrapper(subject: str, message, *args, **kwargs):
                     return single_middleware(subject, message, func, *args, **kwargs)
 
-                async def aio_next_wrapper(subject: str, message, *args, **kwargs):
+                async def async_next_wrapper(subject: str, message, *args, **kwargs):
                     return await single_middleware(
                         subject, message, func, *args, **kwargs
                     )
 
                 if asyncio.iscoroutinefunction(single_middleware):
-                    return aio_next_wrapper
+                    return async_next_wrapper
                 else:
                     return next_wrapper
 
@@ -255,11 +255,11 @@ class _MiddlewareManager:
                 def next_wrapper(msg):
                     return single_middleware(msg, func)
 
-                async def aio_next_wrapper(msg):
+                async def async_next_wrapper(msg):
                     return await single_middleware(msg, func)
 
                 if asyncio.iscoroutinefunction(single_middleware):
-                    return aio_next_wrapper
+                    return async_next_wrapper
                 else:
                     return next_wrapper
 
@@ -309,14 +309,14 @@ class _MiddlewareManager:
                     else:
                         return function_listen_request(msg)
 
-                async def aio_listen_wrapper(msg) -> Callable:
+                async def async_listen_wrapper(msg) -> Callable:
                     if msg.reply == "":
                         return await function_listen_publish(msg)
                     else:
                         return await function_listen_request(msg)
 
                 if asyncio.iscoroutinefunction(function):
-                    return aio_listen_wrapper
+                    return async_listen_wrapper
                 else:
                     return listen_wrapper
 

--- a/panini/nats_client.py
+++ b/panini/nats_client.py
@@ -104,14 +104,14 @@ class NATSClient:
             listen_subjects_callbacks = self.listen_subjects_callbacks
             for subject, callbacks in listen_subjects_callbacks.items():
                 for callback in callbacks:
-                    await self.aio_subscribe_new_subject(
+                    await self.subscribe_new_subject(
                         subject, callback, init_subscription=True
                     )
 
-    def subscribe_new_subject(self, subject: str, callback: CoroutineType):
-        self.loop.run_until_complete(self.aio_subscribe_new_subject(subject, callback))
+    def subscribe_new_subject_sync(self, subject: str, callback: CoroutineType):
+        self.loop.run_until_complete(self.subscribe_new_subject(subject, callback))
 
-    async def aio_subscribe_new_subject(
+    async def subscribe_new_subject(
         self, subject: str, callback: CoroutineType, init_subscription=False
     ):
         callback = _MiddlewareManager._wrap_function_by_middleware("listen")(callback)
@@ -131,10 +131,10 @@ class NATSClient:
             self.listen_subjects_callbacks[subject].append(callback)
         return ssid
 
-    def unsubscribe_subject(self, subject: str):
-        self.loop.run_until_complete(self.aio_unsubscribe_subject(subject))
+    def unsubscribe_subject_sync(self, subject: str):
+        self.loop.run_until_complete(self.unsubscribe_subject(subject))
 
-    async def aio_unsubscribe_subject(self, subject: str):
+    async def unsubscribe_subject(self, subject: str):
         if subject not in self.ssid_map:
             raise Exception(f"Subject {subject} hasn't been subscribed")
         for ssid in self.ssid_map[subject]:
@@ -142,10 +142,10 @@ class NATSClient:
         del self.ssid_map[subject]
         del self.listen_subjects_callbacks[subject]
 
-    def unsubscribe_ssid(self, ssid: int, subject: str = None):
-        self.loop.run_until_complete(self.aio_unsubscribe_ssid(ssid, subject))
+    def unsubscribe_ssid_sync(self, ssid: int, subject: str = None):
+        self.loop.run_until_complete(self.unsubscribe_ssid(ssid, subject))
 
-    async def aio_unsubscribe_ssid(self, ssid: int, subject: str = None):
+    async def unsubscribe_ssid(self, ssid: int, subject: str = None):
         if subject and subject not in self.ssid_map:
             raise Exception(f"Subject {subject} hasn't been subscribed")
         await self.client.unsubscribe(ssid)
@@ -269,10 +269,10 @@ class NATSClient:
             response = response.decode()
         return response
 
-    def disconnect(self):
-        self.loop.run_until_complete(self.aio_disconnect())
+    def disconnect_sync(self):
+        self.loop.run_until_complete(self.disconnect())
 
-    async def aio_disconnect(self):
+    async def disconnect(self):
         await self.client.drain()
         self.log.warning("Disconnected")
 

--- a/panini/nats_client.py
+++ b/panini/nats_client.py
@@ -1,3 +1,4 @@
+import typing
 import ujson
 import asyncio
 import threading
@@ -179,10 +180,11 @@ class NATSClient:
         message,
         timeout: int = 10,
         data_type: type or str = "json.dumps",
+        callback: typing.Callable = None,
     ):
         # asyncio.ensure_future(self.request(subject, message, timeout, data_type))
         return self.loop.run_until_complete(
-            self.request(subject, message, timeout, data_type)
+            self.request(subject, message, timeout, data_type, callback)
         )
 
     def request_from_another_thread_sync(
@@ -273,8 +275,11 @@ class NATSClient:
         message,
         timeout: int = 10,
         data_type: type or str = "json.dumps",
+        callback: typing.Callable = None,
     ):
         message = self.format_message_data_type(message, data_type)
+        if callback is not None:
+            return await self.client.request(subject, message, cb=callback)
         response = await self.client.request(subject, message, timeout=timeout)
         response = response.data
         if data_type == "json.dumps":
@@ -289,9 +294,14 @@ class NATSClient:
         message,
         timeout: int = 10,
         data_type: type or str = "json.dumps",
+        callback: typing.Callable = None,
     ):
         return await self._request_wrapped(
-            subject=subject, message=message, timeout=timeout, data_type=data_type
+            subject=subject,
+            message=message,
+            timeout=timeout,
+            data_type=data_type,
+            callback=callback,
         )
 
     def disconnect_sync(self):

--- a/panini/test_client.py
+++ b/panini/test_client.py
@@ -1,7 +1,6 @@
 import os
 import shutil
 import threading
-import time
 import json
 import random
 import typing
@@ -10,7 +9,6 @@ from urllib.parse import urljoin
 import requests
 import websocket
 from pynats import NATSClient, NATSMessage
-from pynats.exceptions import NATSReadSocketError
 
 from .exceptions import TestClientError
 from .utils.helper import start_process, start_thread

--- a/panini/test_client.py
+++ b/panini/test_client.py
@@ -205,10 +205,12 @@ class TestClient:
             def panini_started(msg):
                 pass
 
-            self.nats_client_sender.subscribe(
+            sub = self.nats_client_sender.subscribe(
                 f"panini_events.{self.panini_service_name}.{self.panini_client_id}.started",
                 callback=panini_started,
+                max_messages=1,
             )
+            self.nats_client_sender.auto_unsubscribe(sub)
 
             self.panini_process = start_process(
                 self.wrap_run_panini,

--- a/panini/utils/logger.py
+++ b/panini/utils/logger.py
@@ -12,7 +12,7 @@ from ..utils import helper
 
 
 # Decorator for check, if logger exist
-def check_logger(func):
+def check_logger_connected(func):
     def wrapper(self, msg, **extra):
         if self.logger is None:
             raise Exception("Logger hasn't been connected")
@@ -30,23 +30,23 @@ class Logger:
     def __init__(self, logger: logging.Logger):
         self.logger = logger
 
-    @check_logger
+    @check_logger_connected
     def debug(self, msg, **extra):
         self.logger.debug(msg, extra={"extra": extra})
 
-    @check_logger
+    @check_logger_connected
     def info(self, msg, **extra):
         self.logger.info(msg, extra={"extra": extra})
 
-    @check_logger
+    @check_logger_connected
     def warning(self, msg, **extra):
         self.logger.warning(msg, extra={"extra": extra})
 
-    @check_logger
+    @check_logger_connected
     def error(self, msg, **extra):
         self.logger.error(msg, extra={"extra": extra})
 
-    @check_logger
+    @check_logger_connected
     def exception(self, msg, **extra):
         self.logger.exception(msg, extra={"extra": extra})
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ The framework allows you to work with NATS features and some additional logic us
 
 setup(
     name="panini",
-    version="0.3.0",
+    version="0.3.1",
     description="A python messaging framework for microservices based on NATS",
     long_description=long_description,
     long_description_content_type="text/x-rst",

--- a/tests/emulator/test_event_storage_middleware.py
+++ b/tests/emulator/test_event_storage_middleware.py
@@ -69,7 +69,7 @@ def run_panini():
 global_object = Global()
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def client():
     client = TestClient(run_panini)
 
@@ -82,7 +82,8 @@ def client():
         pass
 
     client.start(do_always_listen=False)
-    return client
+    yield client
+    client.stop()
 
 
 def test_send_publish_middleware(client):

--- a/tests/emulator/test_event_storage_middleware.py
+++ b/tests/emulator/test_event_storage_middleware.py
@@ -81,7 +81,7 @@ def client():
     def listen_publish_listener(msg):
         pass
 
-    client.start()
+    client.start(do_always_listen=False)
     return client
 
 

--- a/tests/test_client_listen.py
+++ b/tests/test_client_listen.py
@@ -4,13 +4,15 @@ from tests.helper import Global
 # no need to run panini
 client = TestClient()
 
-
 global_object = Global()
 
 
 @client.listen("test_client_listen.foo")
 def foo_listener(msg):
     global_object.public_variable = msg.data["data"] + 1
+
+
+client.start(do_always_listen=False)
 
 
 def test_client_listener():

--- a/tests/test_client_listen_response.py
+++ b/tests/test_client_listen_response.py
@@ -13,6 +13,9 @@ def foo_listener(msg):
     return {"data": msg.data["data"] + 5}
 
 
+client.start()
+
+
 def test_client_response_listener():
     response = client.request("test_client_listen_response.foo", {"data": 1})
 

--- a/tests/test_diff_datatypes.py
+++ b/tests/test_diff_datatypes.py
@@ -106,7 +106,7 @@ def client():
     def dict_listener(msg):
         global_object.public_variable = msg.data["type"]
 
-    client.start()
+    client.start(do_always_listen=False)
     yield client
     client.stop()
 

--- a/tests/test_long_requests.py
+++ b/tests/test_long_requests.py
@@ -1,0 +1,38 @@
+import asyncio
+import time
+
+import pytest
+
+from panini.test_client import TestClient
+from panini import app as panini_app
+
+
+def run_panini():
+    app = panini_app.App(
+        service_name="test_request",
+        host="127.0.0.1",
+        port=4222,
+        logger_in_separate_process=False,
+    )
+
+    @app.listen("test_request.start")
+    async def publish_request(msg):
+        await asyncio.sleep(1.1)
+        return msg.data
+
+    app.start()
+
+
+@pytest.fixture(scope="module")
+def client():
+    client = TestClient(run_panini, socket_timeout=3, listener_socket_timeout=1)
+    client.start()
+    yield client
+    client.stop()
+
+
+def test_publish_request(client):
+    time.sleep(1.5)
+    for _ in range(3):
+        response = client.request("test_request.start", {"success": True})
+        assert response["success"] is True

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -98,7 +98,7 @@ def client():
     def listen_publish_listener(msg):
         global_object.another_variable = msg.data["data"] + 3
 
-    client.start()
+    client.start(do_always_listen=False)
     yield client
     client.stop()
 

--- a/tests/test_non_blocking_request.py
+++ b/tests/test_non_blocking_request.py
@@ -1,0 +1,68 @@
+import asyncio
+
+import pytest
+
+from panini.test_client import TestClient
+from panini import app as panini_app
+
+msg_num = 10
+
+
+def run_panini():
+    app = panini_app.App(
+        service_name="test_non_blocking_request",
+        host="127.0.0.1",
+        port=4222,
+        logger_in_separate_process=False,
+    )
+
+    @app.listen("test_non_blocking_request.start")
+    async def non_blocking_requests(msg):
+        def handle_response(msg):
+            app.publish_sync(
+                "test_non_blocking_request.finalize",
+                {"success": True, "data_type": type(msg.data).__name__},
+            )
+
+        for _ in range(msg_num):
+            await app.request(
+                subject="test_non_blocking_request.foo",
+                message={"data": 1},
+                callback=handle_response,
+            )
+
+        return {"success": True}
+
+    @app.listen("test_non_blocking_request.foo")
+    async def subject_for_requests_listener(msg):
+        await asyncio.sleep(0.5)
+        return {"success": True, "data": "request has been processed"}
+
+    app.start()
+
+
+result = None
+
+
+@pytest.fixture(scope="module")
+def client():
+    client = TestClient(run_panini, socket_timeout=100)
+
+    @client.listen("test_non_blocking_request.finalize")
+    def helper(msg):
+        global result
+        result = msg.data
+
+    client.start(do_always_listen=False)
+    yield client
+    client.stop()
+
+
+def test_non_blocking_request(client):
+    response = client.request("test_non_blocking_request.start", {})
+    assert response["success"] is True
+
+    client.wait(msg_num)
+    assert isinstance(result, dict)
+    assert result["success"] is True
+    assert result["data_type"] == "bytes"

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -35,7 +35,7 @@ def client():
     def bar_listener2(msg):
         global_object.another_variable = msg.data["data"] + 1
 
-    client.start()
+    client.start(do_always_listen=False)
     yield client
     client.stop()
 

--- a/tests/test_reply_to.py
+++ b/tests/test_reply_to.py
@@ -41,7 +41,7 @@ def client():
     def bar_listener(msg):
         global_object.public_variable = msg.data["data"] + 3
 
-    client.start()
+    client.start(do_always_listen=False)
     yield client
     client.stop()
 

--- a/tests/test_request_listen_response.py
+++ b/tests/test_request_listen_response.py
@@ -1,0 +1,41 @@
+import pytest
+from panini.test_client import TestClient
+from panini import app as panini_app
+
+
+def run_panini():
+    app = panini_app.App(
+        service_name="test_request_listen_response", host="127.0.0.1", port=4222
+    )
+
+    @app.listen("test_request_listen_response.start")
+    async def start(msg):
+        await app.request("test_request_listen_response.app.started", {"success": True})
+        return {"success": True}
+
+    app.start()
+
+
+is_app_started = False
+
+
+@pytest.fixture()
+def client():
+    client = TestClient(run_panini)
+
+    @client.listen("test_request_listen_response.app.started")
+    def app_started(msg):
+        global is_app_started
+        is_app_started = True
+        return {"started": True}
+
+    client.start()
+    yield client
+    client.stop()
+
+
+def test_get_token(client):
+    assert is_app_started is False
+    response = client.request("test_request_listen_response.start", {})
+    assert response["success"]
+    assert is_app_started is True

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -32,7 +32,7 @@ def client():
     def foo_listener(msg):
         global_object.public_variable = msg.data["data"] + 1
 
-    client.start()
+    client.start(do_always_listen=False)
     yield client
     client.stop()
 

--- a/tests/test_timer_task.py
+++ b/tests/test_timer_task.py
@@ -34,7 +34,7 @@ def client():
     def foo_listener(msg):
         global_object.another_variable += 2
 
-    client.start()
+    client.start(do_always_listen=False)
     yield client
     client.stop()
 


### PR DESCRIPTION
- Fixed bug with no hinting for publish & request functions 
- Removed 'app_strategy' parameter
- Removed old 'aio' interface for nats_client & managers
- Added auto unsubscribe to test_client waiting for panini to start
- Change ci test flow, add test on python v3.9 -major fixes in TestClient, changes in client.wait() function
- Added non-blocking request support for bytes messages	