### PR TITLE
Optional parameter to inform application layer about validation issue

### DIFF
--- a/panini/managers/event_manager.py
+++ b/panini/managers/event_manager.py
@@ -48,12 +48,12 @@ class EventManager:
             return msg
 
         def wrapper(msg):
-            validate_message(msg)
-            return function(msg)
+            res = validate_message(msg)
+            return function(msg, validation_report=res)
 
         async def wrapper_async(msg):
-            validate_message(msg)
-            return await function(msg)
+            res = validate_message(msg)
+            return await function(msg, validation_report=res)
 
         if asyncio.iscoroutinefunction(function):
             return wrapper_async


### PR DESCRIPTION
Information about validation error appears in log only. 
This fix adds additional optional parameter to function wrapped by 'listen' decorator. 
Parameter 'validation_report' is dict with two fields: 'success' and 'error'. 'success' is boolean and if it's False 'error' contains info from validator about issue.
Application function can check report and makes some logic in case of validation fail (special log, inc some counters and so on),