### PR TITLE
Fixed reconnection problem

### DIFF
--- a/panini/app.py
+++ b/panini/app.py
@@ -335,7 +335,11 @@ class App:
         if self.http_server:
             self.http_server.start_server()
         else:
-            loop.run_until_complete(asyncio.gather(*tasks))
+            try:
+                loop.run_until_complete(asyncio.gather(*tasks))
+            except asyncio.exceptions.CancelledError as exc:
+                self.logger.exception(f"Error: {exc}")
+                self.start()
 
 
 

--- a/panini/app.py
+++ b/panini/app.py
@@ -335,11 +335,7 @@ class App:
         if self.http_server:
             self.http_server.start_server()
         else:
-            try:
-                loop.run_until_complete(asyncio.gather(*tasks))
-            except asyncio.exceptions.CancelledError as exc:
-                self.logger.exception(f"Error: {exc}")
-                self.start()
+            loop.run_until_complete(asyncio.gather(*tasks))
 
 
 

--- a/panini/exceptions.py
+++ b/panini/exceptions.py
@@ -103,3 +103,9 @@ class TestClientError(BaseError):
 
 class JetStreamNotEnabledError(BaseError):
     pass
+
+
+class CriticalError(SystemExit):
+
+    def __init__(self, *args):
+        super().__init__(*args)

--- a/panini/managers/nats_client.py
+++ b/panini/managers/nats_client.py
@@ -99,6 +99,12 @@ class NATSClient:
     def middlewares(self, value: dict):
         self._middleware_manager.middlewares = value
 
+    async def _panini_watcher(self):
+        while True:
+            await asyncio.sleep(0)
+            if not self.client.is_connected and self.client.is_closed:
+                exit(99)
+
     async def _establish_connection(self):
         self.client = NATS()
         if self.servers is None:
@@ -118,6 +124,7 @@ class NATSClient:
             kwargs["reconnect_time_wait"] = self.reconnecting_time_wait
         kwargs.update(self.auth)
         await self.client.connect(**kwargs)
+        self.loop.create_task(self._panini_watcher())
         if self.enable_js:
             self.js_client = self.client.jetstream()
         if self.client.is_connected:


### PR DESCRIPTION
```
 File "/Users/igorhwang/Development/colibriql/panini_microservice_template/venv/lib/python3.10/site-packages/nats/aio/client.py", line 1844, in _ping_interval
    await asyncio.sleep(self.options["ping_interval"])
```

Usually on reconnect, this line fails with `asyncio.exceptions.CancelledError` and connection crashes because of `loop.run_until_complete`. It doesn't fail when it is run with `loop.run_forever()`, but in that case all continuous tasks are lost because nats takes full thread and never releases it.

~This commit fixes problem described above by wrapping `loop.run_until_complete` with try/except block to ignore ping_interval exception mentioned above.~

~Best case scenario would be wrapping `app.start()` in microservice with try/except block as well like this:~

```
from nats.errors import NoServersError
try:
    app.start()
except NoServersError:
    # Fires only when all reconnect attempts failed
    exit(1)
```

~Can be used for watching microservice status and fire only when no reconnection attempts are available - for example to alert owner. Doesn't fire on reconnect.~

July 26 update:

https://github.com/lwinterface/panini/pull/236/commits/fc9aaad3393a5a54a1b04d9b7f0d75c653571ffb approaches to the problem differently:

1. Added panini custom exception named CriticalError, which you can call anywhere in the code to terminate panini process (nats task or web server). !NB! Ordinary exceptions do not break panini process. Should terminate with raising CriticalError
2. Connecting to invalid broker (wrong IP / port) now forcing panini to reconnect to nats and when failed n + 1 times (in case allow_reconnect = True and max_reconnect_attempts = n panini terminates process with exit code 1 and nats.errors.NoServersError as last error.
3. Connecting to multiple brokers and disconnecting them (network cut out, broker crash, etc) results in n+ 1 attempts to reconnect and then panini terminates process with exit code 99
4. Aiohttp mode goes along with panini and if panini terminates its process, webserver follows.