### PR TITLE
Fixed CPU overconsumption

### DIFF
--- a/panini/managers/nats_client.py
+++ b/panini/managers/nats_client.py
@@ -101,7 +101,7 @@ class NATSClient:
 
     async def _panini_watcher(self):
         while True:
-            await asyncio.sleep(5)
+            await asyncio.sleep(0.1)
             if not self.client.is_connected and self.client.is_closed:
                 exit(99)
 

--- a/panini/managers/nats_client.py
+++ b/panini/managers/nats_client.py
@@ -101,7 +101,7 @@ class NATSClient:
 
     async def _panini_watcher(self):
         while True:
-            await asyncio.sleep(0.1)
+            await asyncio.sleep(1)
             if not self.client.is_connected and self.client.is_closed:
                 exit(99)
 

--- a/panini/managers/nats_client.py
+++ b/panini/managers/nats_client.py
@@ -101,7 +101,7 @@ class NATSClient:
 
     async def _panini_watcher(self):
         while True:
-            await asyncio.sleep(0)
+            await asyncio.sleep(5)
             if not self.client.is_connected and self.client.is_closed:
                 exit(99)
 


### PR DESCRIPTION
Tested different variations, sleeping 0.1 seconds increases CPU consumption by 0.2%. Exceptions are also tested, shutting down panini as expected. 