### PR TITLE
Fail tolerance: ignore exceptions in main loop

### DIFF
--- a/panini/app.py
+++ b/panini/app.py
@@ -452,7 +452,7 @@ class App:
         if self.http_server:
             self.http_server.start_server()
         else:
-            loop.run_until_complete(asyncio.gather(*tasks))
+            loop.run_until_complete(asyncio.gather(*tasks, return_exceptions=True))
 
 
 


### PR DESCRIPTION
Any internal exception in NATS leads to a crash of entire app