### PR TITLE
Refactor tracing middleware

### DIFF
--- a/examples/tracing_middleware_compose/requirements.txt
+++ b/examples/tracing_middleware_compose/requirements.txt
@@ -4,4 +4,4 @@ opentelemetry-sdk==1.15.0
 opentelemetry-exporter-otlp-proto-grpc==1.15.0
 opentelemetry-exporter-prometheus==1.12.0rc1
 python-logging-loki==0.3.1
-PyYAML==5.4
+PyYAML==6.0.1

--- a/examples/tracing_middleware_compose/tracing_middleware_config.yaml
+++ b/examples/tracing_middleware_compose/tracing_middleware_config.yaml
@@ -1,6 +1,6 @@
 service_name: abcdef
 exporter_config:
-  endpoint: localhost:4317
+  endpoint: open_telemetry:4317
   insecure: yes
   headers: null
   timeout: null

--- a/panini/managers/middleware_manager.py
+++ b/panini/managers/middleware_manager.py
@@ -45,17 +45,6 @@ class MiddlewareManager:
         ), f"At least one of the following functions must be implemented: {high_priority_functions + global_functions}"
 
         middleware_obj = middleware_cls(*args, **kwargs)
-        # Check if Tracing Middleware is first in order when adding middlewares
-        class_name = middleware_obj.__class__.__name__
-        middlewares = self._middlewares
-
-        listen_publish_middleware_exists = middlewares.get('listen_publish_middleware')
-        listen_request_middleware_exists = middlewares.get('listen_request_middleware')
-
-        if (class_name == 'TracingMiddleware' and
-                listen_publish_middleware_exists and
-                listen_request_middleware_exists):
-            raise Exception("TracingMiddleware should be placed first when adding middlewares!")
         for function_name in high_priority_functions:
             if function_name in middleware_cls.__dict__:
                 self._middlewares[f"{function_name}_middleware"].append(

--- a/panini/middleware/tracing_middleware.py
+++ b/panini/middleware/tracing_middleware.py
@@ -5,213 +5,218 @@ try:
     from opentelemetry.sdk.resources import SERVICE_NAME, Resource
     from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
     from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
-    import inspect
-    import uuid
-    import json
-    from functools import wraps
-    from typing import Optional
-    from nats.aio.msg import Msg
-    from panini.app import get_app
-    from dataclasses import dataclass
-    from panini.middleware import Middleware
-    from panini.managers.event_manager import Listen
-
-
-    @dataclass
-    class SpanConfig:
-        """
-         Represents a configuration for a span.
-        Attributes:
-            span_name (str): The name of the span.
-            span_attributes (Optional[dict]): The optional dictionary of attributes for the span.
-        """
-        span_name: str
-        span_attributes: Optional[dict]
-
-
-    def register_trace(**decorator_kwargs):  # the decorator
-        def wrapper(f):  # a wrapper for the function
-            if inspect.iscoroutinefunction(f):
-                @wraps(f)
-                async def decorated_function(*args, **kwargs):  # the decorated function
-                    ctx = trace.get_current_span().get_span_context()
-                    link = trace.Link(ctx)
-                    _tracer = trace.get_tracer(__name__)
-                    with _tracer.start_as_current_span(decorator_kwargs.get("span_name", f"unknown-{uuid.uuid4().hex}"),
-                                                       links=[link]):
-                        result = await f(*args, **kwargs)
-                    return result
-            else:
-                @wraps(f)
-                def decorated_function(*args, **kwargs):  # the decorated function
-                    ctx = trace.get_current_span().get_span_context()
-                    link = trace.Link(ctx)
-                    _tracer = trace.get_tracer(__name__)
-                    with _tracer.start_as_current_span(decorator_kwargs.get("span_name", f"unknown-{uuid.uuid4().hex}"),
-                                                       links=[link]):
-                        result = f(*args, **kwargs)
-                    return result
-
-            return decorated_function
-
-        return wrapper
-
-
-    class OTELTracer:
-        """
-        The OTELTracer class is used to create and configure an OpenTelemetry tracer for distributed tracing.
-        Attributes:
-            tracing_config (dict): The configuration dictionary containing the tracing settings.
-            service_name (str): The name of the service being traced.
-            _config (dict): The internal configuration dictionary.
-            _exporter_config (dict): The configuration for the tracer exporter.
-            _provider_config (dict): The configuration for the tracer provider.
-            _custom_config (dict): Additional custom configuration provided by the user.
-            tracer: The OpenTelemetry tracer instance.
-        Methods:
-            __init__(self, tracing_config: dict, **kwargs)
-                Initializes a new instance of the OTELTracer class.
-                Args:
-                    tracing_config (dict): The configuration dictionary containing the tracing settings.
-                    **kwargs: Additional custom configuration parameters.
-            create_tracer(self)
-                Creates and configures the OpenTelemetry tracer.
-                Returns:
-                    The initialized OpenTelemetry tracer instance.
-        """
-
-        def __init__(self, tracing_config: dict, **kwargs):
-            self._config = tracing_config
-            self.service_name = self._config["service_name"]
-            self._exporter_config = self._config["exporter_config"]
-            self._provider_config = self._config["provider_config"]
-            self._custom_config = self._config["custom_config"]
-            self._custom_config.update(**kwargs)
-            self.tracer = self.create_tracer()
-
-        def create_tracer(self):
-            resource = Resource(attributes={
-                SERVICE_NAME: self.service_name
-            })
-            provider = TracerProvider(resource=resource, **self._provider_config)
-            processor = BatchSpanProcessor(OTLPSpanExporter(**self._exporter_config))
-            provider.add_span_processor(processor)
-            trace.set_tracer_provider(provider)
-            return trace.get_tracer(__name__)
-
-
-    class TracingMiddleware(Middleware):
-        """
-        Class representing a middleware for tracing requests and events in a Panini application.
-        Args:
-            tracing_config (dict): A dictionary containing the configuration parameters for tracing.
-        Attributes:
-            _otel_tracer (OTELTracer): The OpenTelemetry Tracer instance.
-            tracer (Tracer): The Tracer instance extracted from _otel_tracer.
-            parent (TraceContextTextMapPropagator): The Trace Context TextMap Propagator instance.
-        Methods:
-            _create_uuid(): Generates a UUID v4 string.
-            send_any(subject: str, message: Msg, send_func, *args, **kwargs): Sends a message with tracing information.
-            wildcard_match(match_key: str, subject: str) -> str: Performs a wildcard match between two strings.
-            listen_any(msg: Msg, callback): Listens for events with tracing information.
-        """
-
-        def __init__(
-                self,
-                tracing_config: dict,
-                **kwargs
-        ):
-            self._otel_tracer = OTELTracer(tracing_config=tracing_config, **kwargs)
-            self.tracer: Tracer = self._otel_tracer.tracer
-            self.parent = TraceContextTextMapPropagator()
-            super().__init__()
-
-        def _create_uuid(self) -> str:
-            return uuid.uuid4().hex
-
-        async def send_any(self, subject: str, message: Msg, send_func, *args, **kwargs):
-            carrier = {}
-            headers = {}
-            span_config = kwargs.get("span_config")
-            use_tracing = kwargs.get("use_tracing", True)
-            if kwargs.get("use_current_span", False):
-                ctx = trace.get_current_span().get_span_context()
-                link = [trace.Link(ctx)]
-            else:
-                link = []
-            if not isinstance(span_config, SpanConfig):
-                span_config = SpanConfig(
-                    span_name=self._create_uuid(),
-                    span_attributes={})
-            if use_tracing is True and span_config:
-                with self.tracer.start_as_current_span(span_config.span_name, links=link) as span:
-                    for attr_key, attr_value in span_config.span_attributes.items():
-                        span.set_attribute(attr_key, attr_value)
-                    self.parent.inject(carrier=carrier)
-                    headers = {
-                        "tracing_span_name": span_config.span_name,
-                        "tracing_span_carrier": json.dumps(carrier)
-                    }
-            if "use_tracing" in kwargs:
-                del kwargs['use_tracing']
-            response = await send_func(subject, message, headers=headers)
-            return response
-
-        @classmethod
-        def wildcard_match(cls, match_key: str, subject: str) -> Optional[str]:
-            """Perform a wildcard match between the match_key and the subject"""
-            split_subject = subject.split('.')
-            split_key = match_key.split('.')
-
-            # if `>` at the end of match_key
-            if split_key[-1] == '>':
-                if len(split_subject) < len(split_key) - 1:  # -1 because `>` matches remaining parts
-                    return None
-                # checking parts before `>` match
-                for k, s in zip(split_key[:-1], split_subject):
-                    if k != "*" and k != s:
-                        return None
-                # parts before `>` matched in both
-                return match_key
-
-            # if not `>` at the end
-            if len(split_subject) != len(split_key):
-                return None
-
-            if all(k == "*" or k == s for k, s in zip(split_key, split_subject)):
-                return match_key
-
-            return None
-
-        async def listen_any(self, msg: Msg, callback):
-            context = {}
-            app = get_app()
-            assert app is not None
-            for subject in app._event_manager.subscriptions.keys():
-                matched_subject = self.wildcard_match(subject, msg.subject)
-                if not matched_subject:
-                    continue
-                listen_obj_list = app._event_manager.subscriptions[matched_subject]
-                listen_object: Listen
-                for listen_object in listen_obj_list:
-                    use_tracing = listen_object._meta.get("use_tracing", True)
-                    if use_tracing:
-                        if id(callback) == id(
-                                listen_object.callback) and callback.__name__ == listen_object.callback.__name__:
-                            headers = msg.headers
-                            if headers:
-                                context = self.parent.extract(
-                                    carrier=json.loads(msg.headers.get("tracing_span_carrier", "{}")))
-                            span_config = listen_object._meta.get("span_config")
-                            if not isinstance(span_config, SpanConfig):
-                                span_config = SpanConfig(
-                                    span_name=self._create_uuid(),
-                                    span_attributes={})
-                            with self.tracer.start_as_current_span(span_config.span_name, context=context) as span:
-                                for attr_key, attr_val in span_config.span_attributes.items():
-                                    span.set_attribute(attr_key, attr_val)
-                                response = await callback(msg)
-                                return response
-            return await callback(msg)
 except ImportError:
     raise Exception("Tracing dependencies not found, try to run `$ pip install panini[tracing]`")
+import inspect
+import uuid
+import json
+from functools import wraps
+from typing import Optional
+from nats.aio.msg import Msg
+from panini.app import get_app
+from dataclasses import dataclass
+from panini.middleware import Middleware
+from panini.managers.event_manager import Listen
+import warnings
+
+
+@dataclass
+class SpanConfig:
+    """
+     Represents a configuration for a span.
+    Attributes:
+        span_name (str): The name of the span.
+        span_attributes (Optional[dict]): The optional dictionary of attributes for the span.
+    """
+    span_name: str
+    span_attributes: Optional[dict]
+
+
+def register_trace(**decorator_kwargs):  # the decorator
+    def wrapper(f):  # a wrapper for the function
+        if inspect.iscoroutinefunction(f):
+            @wraps(f)
+            async def decorated_function(*args, **kwargs):  # the decorated function
+                ctx = trace.get_current_span().get_span_context()
+                link = trace.Link(ctx)
+                _tracer = trace.get_tracer(__name__)
+                with _tracer.start_as_current_span(decorator_kwargs.get("span_name", f"unknown-{uuid.uuid4().hex}"),
+                                                   links=[link]):
+                    result = await f(*args, **kwargs)
+                return result
+        else:
+            @wraps(f)
+            def decorated_function(*args, **kwargs):  # the decorated function
+                ctx = trace.get_current_span().get_span_context()
+                link = trace.Link(ctx)
+                _tracer = trace.get_tracer(__name__)
+                with _tracer.start_as_current_span(decorator_kwargs.get("span_name", f"unknown-{uuid.uuid4().hex}"),
+                                                   links=[link]):
+                    result = f(*args, **kwargs)
+                return result
+
+        return decorated_function
+
+    return wrapper
+
+
+class OTELTracer:
+    """
+    The OTELTracer class is used to create and configure an OpenTelemetry tracer for distributed tracing.
+    Attributes:
+        tracing_config (dict): The configuration dictionary containing the tracing settings.
+        service_name (str): The name of the service being traced.
+        _config (dict): The internal configuration dictionary.
+        _exporter_config (dict): The configuration for the tracer exporter.
+        _provider_config (dict): The configuration for the tracer provider.
+        _custom_config (dict): Additional custom configuration provided by the user.
+        tracer: The OpenTelemetry tracer instance.
+    Methods:
+        __init__(self, tracing_config: dict, **kwargs)
+            Initializes a new instance of the OTELTracer class.
+            Args:
+                tracing_config (dict): The configuration dictionary containing the tracing settings.
+                **kwargs: Additional custom configuration parameters.
+        create_tracer(self)
+            Creates and configures the OpenTelemetry tracer.
+            Returns:
+                The initialized OpenTelemetry tracer instance.
+    """
+
+    def __init__(self, tracing_config: dict, **kwargs):
+        self._config = tracing_config
+        self.service_name = self._config["service_name"]
+        self._exporter_config = self._config["exporter_config"]
+        self._provider_config = self._config["provider_config"]
+        self._custom_config = self._config["custom_config"]
+        self._custom_config.update(**kwargs)
+        self.tracer = self.create_tracer()
+
+    def create_tracer(self):
+        resource = Resource(attributes={
+            SERVICE_NAME: self.service_name
+        })
+        provider = TracerProvider(resource=resource, **self._provider_config)
+        processor = BatchSpanProcessor(OTLPSpanExporter(**self._exporter_config))
+        provider.add_span_processor(processor)
+        trace.set_tracer_provider(provider)
+        return trace.get_tracer(__name__)
+
+
+class TracingMiddleware(Middleware):
+    """
+    Class representing a middleware for tracing requests and events in a Panini application.
+    Args:
+        tracing_config (dict): A dictionary containing the configuration parameters for tracing.
+    Attributes:
+        _otel_tracer (OTELTracer): The OpenTelemetry Tracer instance.
+        tracer (Tracer): The Tracer instance extracted from _otel_tracer.
+        parent (TraceContextTextMapPropagator): The Trace Context TextMap Propagator instance.
+    Methods:
+        _create_uuid(): Generates a UUID v4 string.
+        send_any(subject: str, message: Msg, send_func, *args, **kwargs): Sends a message with tracing information.
+        wildcard_match(match_key: str, subject: str) -> str: Performs a wildcard match between two strings.
+        listen_any(msg: Msg, callback): Listens for events with tracing information.
+    """
+
+    def __init__(
+            self,
+            tracing_config: dict,
+            **kwargs
+    ):
+        self._otel_tracer = OTELTracer(tracing_config=tracing_config, **kwargs)
+        self.tracer: Tracer = self._otel_tracer.tracer
+        self.parent = TraceContextTextMapPropagator()
+        super().__init__()
+
+    def _create_uuid(self) -> str:
+        return uuid.uuid4().hex
+
+    async def send_any(self, subject: str, message: Msg, send_func, *args, **kwargs):
+        carrier = {}
+        headers = {}
+        span_config = kwargs.get("span_config")
+        use_tracing = kwargs.get("use_tracing", True)
+        if kwargs.get("use_current_span", False):
+            ctx = trace.get_current_span().get_span_context()
+            link = [trace.Link(ctx)]
+        else:
+            link = []
+        if not isinstance(span_config, SpanConfig):
+            span_config = SpanConfig(
+                span_name=self._create_uuid(),
+                span_attributes={})
+        if use_tracing is True and span_config:
+            with self.tracer.start_as_current_span(span_config.span_name, links=link) as span:
+                for attr_key, attr_value in span_config.span_attributes.items():
+                    span.set_attribute(attr_key, attr_value)
+                self.parent.inject(carrier=carrier)
+                headers = {
+                    "tracing_span_name": span_config.span_name,
+                    "tracing_span_carrier": json.dumps(carrier)
+                }
+        if "use_tracing" in kwargs:
+            del kwargs['use_tracing']
+        response = await send_func(subject, message, headers=headers)
+        return response
+
+    @classmethod
+    def wildcard_match(cls, match_key: str, subject: str) -> Optional[str]:
+        """Perform a wildcard match between the match_key and the subject"""
+        split_subject = subject.split('.')
+        split_key = match_key.split('.')
+
+        # if `>` at the end of match_key
+        if split_key[-1] == '>':
+            if len(split_subject) < len(split_key) - 1:  # -1 because `>` matches remaining parts
+                return None
+            # checking parts before `>` match
+            for k, s in zip(split_key[:-1], split_subject):
+                if k != "*" and k != s:
+                    return None
+            # parts before `>` matched in both
+            return match_key
+
+        # if not `>` at the end
+        if len(split_subject) != len(split_key):
+            return None
+
+        if all(k == "*" or k == s for k, s in zip(split_key, split_subject)):
+            return match_key
+
+        return None
+
+    async def listen_any(self, msg: Msg, callback):
+        context = {}
+        app = get_app()
+        assert app is not None
+        for subject in app._event_manager.subscriptions.keys():
+            matched_subject = self.wildcard_match(subject, msg.subject)
+            if not matched_subject:
+                continue
+            listen_obj_list = app._event_manager.subscriptions[matched_subject]
+            listen_object: Listen
+            for listen_object in listen_obj_list:
+                use_tracing = listen_object._meta.get("use_tracing", True)
+                if use_tracing:
+                    if id(callback) == id(
+                            listen_object.callback) and callback.__name__ == listen_object.callback.__name__:
+                        headers = msg.headers
+                        if headers:
+                            context = self.parent.extract(
+                                carrier=json.loads(msg.headers.get("tracing_span_carrier", "{}")))
+                        span_config = listen_object._meta.get("span_config")
+                        if not isinstance(span_config, SpanConfig):
+                            span_config = SpanConfig(
+                                span_name=self._create_uuid(),
+                                span_attributes={})
+                        with self.tracer.start_as_current_span(span_config.span_name, context=context) as span:
+                            for attr_key, attr_val in span_config.span_attributes.items():
+                                span.set_attribute(attr_key, attr_val)
+                            response = await callback(msg)
+                            return response
+                    else:
+                        warnings.warn(
+                            "TracingMiddleware logic on listener doesn't work, it should be placed first when adding middlewares!")
+                        return await callback(msg)
+        return await callback(msg)

--- a/panini/middleware/tracing_middleware.py
+++ b/panini/middleware/tracing_middleware.py
@@ -1,139 +1,217 @@
-import inspect
-import uuid
-import json
-from functools import wraps
-from typing import Optional
-from nats.aio.msg import Msg
-from panini.app import get_app
-from opentelemetry import trace
-from dataclasses import dataclass
-from panini.middleware import Middleware
-from panini.managers.event_manager import Listen
-from opentelemetry.sdk.trace import TracerProvider, Tracer
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.sdk.resources import SERVICE_NAME, Resource
-from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
-from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+try:
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider, Tracer
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+    from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+    import inspect
+    import uuid
+    import json
+    from functools import wraps
+    from typing import Optional
+    from nats.aio.msg import Msg
+    from panini.app import get_app
+    from dataclasses import dataclass
+    from panini.middleware import Middleware
+    from panini.managers.event_manager import Listen
 
 
-@dataclass
-class SpanConfig:
-    span_name: str
-    span_attributes: Optional[dict]
+    @dataclass
+    class SpanConfig:
+        """
+         Represents a configuration for a span.
+        Attributes:
+            span_name (str): The name of the span.
+            span_attributes (Optional[dict]): The optional dictionary of attributes for the span.
+        """
+        span_name: str
+        span_attributes: Optional[dict]
 
 
-def register_trace(**decorator_kwargs):  # the decorator
-    def wrapper(f):  # a wrapper for the function
-        if inspect.iscoroutinefunction(f):
-            @wraps(f)
-            async def decorated_function(*args, **kwargs):  # the decorated function
+    def register_trace(**decorator_kwargs):  # the decorator
+        def wrapper(f):  # a wrapper for the function
+            if inspect.iscoroutinefunction(f):
+                @wraps(f)
+                async def decorated_function(*args, **kwargs):  # the decorated function
+                    ctx = trace.get_current_span().get_span_context()
+                    link = trace.Link(ctx)
+                    _tracer = trace.get_tracer(__name__)
+                    with _tracer.start_as_current_span(decorator_kwargs.get("span_name", f"unknown-{uuid.uuid4().hex}"),
+                                                       links=[link]):
+                        result = await f(*args, **kwargs)
+                    return result
+            else:
+                @wraps(f)
+                def decorated_function(*args, **kwargs):  # the decorated function
+                    ctx = trace.get_current_span().get_span_context()
+                    link = trace.Link(ctx)
+                    _tracer = trace.get_tracer(__name__)
+                    with _tracer.start_as_current_span(decorator_kwargs.get("span_name", f"unknown-{uuid.uuid4().hex}"),
+                                                       links=[link]):
+                        result = f(*args, **kwargs)
+                    return result
+
+            return decorated_function
+
+        return wrapper
+
+
+    class OTELTracer:
+        """
+        The OTELTracer class is used to create and configure an OpenTelemetry tracer for distributed tracing.
+        Attributes:
+            tracing_config (dict): The configuration dictionary containing the tracing settings.
+            service_name (str): The name of the service being traced.
+            _config (dict): The internal configuration dictionary.
+            _exporter_config (dict): The configuration for the tracer exporter.
+            _provider_config (dict): The configuration for the tracer provider.
+            _custom_config (dict): Additional custom configuration provided by the user.
+            tracer: The OpenTelemetry tracer instance.
+        Methods:
+            __init__(self, tracing_config: dict, **kwargs)
+                Initializes a new instance of the OTELTracer class.
+                Args:
+                    tracing_config (dict): The configuration dictionary containing the tracing settings.
+                    **kwargs: Additional custom configuration parameters.
+            create_tracer(self)
+                Creates and configures the OpenTelemetry tracer.
+                Returns:
+                    The initialized OpenTelemetry tracer instance.
+        """
+
+        def __init__(self, tracing_config: dict, **kwargs):
+            self._config = tracing_config
+            self.service_name = self._config["service_name"]
+            self._exporter_config = self._config["exporter_config"]
+            self._provider_config = self._config["provider_config"]
+            self._custom_config = self._config["custom_config"]
+            self._custom_config.update(**kwargs)
+            self.tracer = self.create_tracer()
+
+        def create_tracer(self):
+            resource = Resource(attributes={
+                SERVICE_NAME: self.service_name
+            })
+            provider = TracerProvider(resource=resource, **self._provider_config)
+            processor = BatchSpanProcessor(OTLPSpanExporter(**self._exporter_config))
+            provider.add_span_processor(processor)
+            trace.set_tracer_provider(provider)
+            return trace.get_tracer(__name__)
+
+
+    class TracingMiddleware(Middleware):
+        """
+        Class representing a middleware for tracing requests and events in a Panini application.
+        Args:
+            tracing_config (dict): A dictionary containing the configuration parameters for tracing.
+        Attributes:
+            _otel_tracer (OTELTracer): The OpenTelemetry Tracer instance.
+            tracer (Tracer): The Tracer instance extracted from _otel_tracer.
+            parent (TraceContextTextMapPropagator): The Trace Context TextMap Propagator instance.
+        Methods:
+            _create_uuid(): Generates a UUID v4 string.
+            send_any(subject: str, message: Msg, send_func, *args, **kwargs): Sends a message with tracing information.
+            wildcard_match(match_key: str, subject: str) -> str: Performs a wildcard match between two strings.
+            listen_any(msg: Msg, callback): Listens for events with tracing information.
+        """
+
+        def __init__(
+                self,
+                tracing_config: dict,
+                **kwargs
+        ):
+            self._otel_tracer = OTELTracer(tracing_config=tracing_config, **kwargs)
+            self.tracer: Tracer = self._otel_tracer.tracer
+            self.parent = TraceContextTextMapPropagator()
+            super().__init__()
+
+        def _create_uuid(self) -> str:
+            return uuid.uuid4().hex
+
+        async def send_any(self, subject: str, message: Msg, send_func, *args, **kwargs):
+            carrier = {}
+            headers = {}
+            span_config = kwargs.get("span_config")
+            use_tracing = kwargs.get("use_tracing", True)
+            if kwargs.get("use_current_span", False):
                 ctx = trace.get_current_span().get_span_context()
-                link = trace.Link(ctx)
-                _tracer = trace.get_tracer(__name__)
-                with _tracer.start_as_current_span(decorator_kwargs.get("span_name", f"unknown-{uuid.uuid4().hex}"),
-                                                  links=[link]):
-                    result = await f(*args, **kwargs)
-                return result
-        else:
-            @wraps(f)
-            def decorated_function(*args, **kwargs):  # the decorated function
-                ctx = trace.get_current_span().get_span_context()
-                link = trace.Link(ctx)
-                _tracer = trace.get_tracer(__name__)
-                with _tracer.start_as_current_span(decorator_kwargs.get("span_name", f"unknown-{uuid.uuid4().hex}"),
-                                                  links=[link]):
-                    result = f(*args, **kwargs)
-                return result
+                link = [trace.Link(ctx)]
+            else:
+                link = []
+            if not isinstance(span_config, SpanConfig):
+                span_config = SpanConfig(
+                    span_name=self._create_uuid(),
+                    span_attributes={})
+            if use_tracing is True and span_config:
+                with self.tracer.start_as_current_span(span_config.span_name, links=link) as span:
+                    for attr_key, attr_value in span_config.span_attributes.items():
+                        span.set_attribute(attr_key, attr_value)
+                    self.parent.inject(carrier=carrier)
+                    headers = {
+                        "tracing_span_name": span_config.span_name,
+                        "tracing_span_carrier": json.dumps(carrier)
+                    }
+            if "use_tracing" in kwargs:
+                del kwargs['use_tracing']
+            response = await send_func(subject, message, headers=headers)
+            return response
 
-        return decorated_function
+        @classmethod
+        def wildcard_match(cls, match_key: str, subject: str) -> Optional[str]:
+            """Perform a wildcard match between the match_key and the subject"""
+            split_subject = subject.split('.')
+            split_key = match_key.split('.')
 
-    return wrapper
+            # if `>` at the end of match_key
+            if split_key[-1] == '>':
+                if len(split_subject) < len(split_key) - 1:  # -1 because `>` matches remaining parts
+                    return None
+                # checking parts before `>` match
+                for k, s in zip(split_key[:-1], split_subject):
+                    if k != "*" and k != s:
+                        return None
+                # parts before `>` matched in both
+                return match_key
 
+            # if not `>` at the end
+            if len(split_subject) != len(split_key):
+                return None
 
-class OTELTracer:
-    def __init__(self, tracing_config: dict, **kwargs):
-        self._config = tracing_config
-        self.service_name = self._config["service_name"]
-        self._exporter_config = self._config["exporter_config"]
-        self._provider_config = self._config["provider_config"]
-        self._custom_config = self._config["custom_config"]
-        self._custom_config.update(**kwargs)
-        self.tracer = self.create_tracer()
+            if all(k == "*" or k == s for k, s in zip(split_key, split_subject)):
+                return match_key
 
-    def create_tracer(self):
-        resource = Resource(attributes={
-            SERVICE_NAME: self.service_name
-        })
-        provider = TracerProvider(resource=resource, **self._provider_config)
-        processor = BatchSpanProcessor(OTLPSpanExporter(**self._exporter_config))
-        provider.add_span_processor(processor)
-        trace.set_tracer_provider(provider)
-        return trace.get_tracer(__name__)
+            return None
 
-
-class TracingMiddleware(Middleware):
-    def __init__(
-            self,
-            tracing_config: dict,
-            **kwargs
-    ):
-        self._otel_tracer = OTELTracer(tracing_config=tracing_config, **kwargs)
-        self.tracer: Tracer = self._otel_tracer.tracer
-        self.parent = TraceContextTextMapPropagator()
-        super().__init__()
-
-    def _create_uuid(self) -> str:
-        return uuid.uuid4().hex
-
-    async def send_any(self, subject: str, message: Msg, send_func, *args, **kwargs):
-        carrier = {}
-        headers = {}
-        span_config = kwargs.get("span_config")
-        use_tracing = kwargs.get("use_tracing", True)
-        if kwargs.get("use_current_span", False):
-            ctx = trace.get_current_span().get_span_context()
-            link = [trace.Link(ctx)]
-        else:
-            link = []
-        if not isinstance(span_config, SpanConfig):
-            span_config = SpanConfig(
-                span_name=self._create_uuid(),
-                span_attributes={})
-        if use_tracing is True and span_config:
-            with self.tracer.start_as_current_span(span_config.span_name, links=link) as span:
-                for attr_key, attr_value in span_config.span_attributes.items():
-                    span.set_attribute(attr_key, attr_value)
-                self.parent.inject(carrier=carrier)
-                headers = {
-                    "tracing_span_name": span_config.span_name,
-                    "tracing_span_carrier": json.dumps(carrier)
-                }
-        if "use_tracing" in kwargs:
-            del kwargs['use_tracing']
-        response = await send_func(subject, message, headers=headers)
-        return response
-
-    async def listen_any(self, msg: Msg, callback):
-        context = {}
-        app = get_app()
-        assert app is not None
-        listen_obj_list = app._event_manager.subscriptions[msg.subject]
-        for index in range(0, len(listen_obj_list)):
-            listen_object: Listen = listen_obj_list[index]
-            use_tracing = listen_object._meta.get("use_tracing", True)
-            if use_tracing:
-                if id(callback) == id(listen_object.callback) and callback.__name__ == listen_object.callback.__name__:
-                    headers = msg.headers
-                    if headers:
-                        context = self.parent.extract(carrier=json.loads(msg.headers.get("tracing_span_carrier", "{}")))
-                    span_config = listen_object._meta.get("span_config")
-                    if not isinstance(span_config, SpanConfig):
-                        span_config = SpanConfig(
-                            span_name=self._create_uuid(),
-                            span_attributes={})
-                    with self.tracer.start_as_current_span(span_config.span_name, context=context) as span:
-                        for attr_key, attr_val in span_config.span_attributes.items():
-                            span.set_attribute(attr_key, attr_val)
-                        response = await callback(msg)
-                        return response
-        return await callback(msg)
+        async def listen_any(self, msg: Msg, callback):
+            context = {}
+            app = get_app()
+            assert app is not None
+            for subject in app._event_manager.subscriptions.keys():
+                matched_subject = self.wildcard_match(subject, msg.subject)
+                if not matched_subject:
+                    continue
+                listen_obj_list = app._event_manager.subscriptions[matched_subject]
+                listen_object: Listen
+                for listen_object in listen_obj_list:
+                    use_tracing = listen_object._meta.get("use_tracing", True)
+                    if use_tracing:
+                        if id(callback) == id(
+                                listen_object.callback) and callback.__name__ == listen_object.callback.__name__:
+                            headers = msg.headers
+                            if headers:
+                                context = self.parent.extract(
+                                    carrier=json.loads(msg.headers.get("tracing_span_carrier", "{}")))
+                            span_config = listen_object._meta.get("span_config")
+                            if not isinstance(span_config, SpanConfig):
+                                span_config = SpanConfig(
+                                    span_name=self._create_uuid(),
+                                    span_attributes={})
+                            with self.tracer.start_as_current_span(span_config.span_name, context=context) as span:
+                                for attr_key, attr_val in span_config.span_attributes.items():
+                                    span.set_attribute(attr_key, attr_val)
+                                response = await callback(msg)
+                                return response
+            return await callback(msg)
+except ImportError:
+    raise Exception("Tracing dependencies not found, try to run `$ pip install panini[tracing]`")

--- a/requirements/defaults.txt
+++ b/requirements/defaults.txt
@@ -1,7 +1,7 @@
 aiohttp==3.8.1
 aiohttp-cors==0.7.0
 async-timeout==4.0.0
-requests==2.24.0
+requests==2.31.0
 six==1.16.0
 nats-py==2.0.0
 nats-python==0.8.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,8 @@
 [metadata]
 description-file = README.md
+
+[options.extras_require]
+tracing = opentelemetry-api==1.15.0
+          opentelemetry-sdk==1.15.0
+          opentelemetry-exporter-otlp-proto-grpc==1.15.0
+          opentelemetry-exporter-prometheus==1.12.0rc1

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,13 @@ The framework allows you to work with NATS features and some additional logic us
 
 """
 
+tracing_dependencies = [
+    "opentelemetry-api==1.15.0",
+    "opentelemetry-sdk==1.15.0",
+    "opentelemetry-exporter-otlp-proto-grpc==1.15.0",
+    "opentelemetry-exporter-prometheus==1.12.0rc1"
+]
+
 setup(
     name="panini",
     version="0.8.1",
@@ -53,7 +60,7 @@ setup(
         "async-timeout==4.0.0",
         "nats-py==2.2.0",
         "websocket-client>=1.2.3",
-        "requests>=2.24.0",
+        "requests>=2.31.0",
         "six>=1.15.0",
         "yarl>=1.6.1",
         "python-json-logger>=2.0.1",
@@ -76,4 +83,7 @@ setup(
         "Source": "https://github.com/lwinterface/panini/",
     },
     zip_safe=False,
+    extras_required={
+        'tracing': tracing_dependencies
+    }
 )


### PR DESCRIPTION
1. Reworked tracing middleware to accept and work with subjects with wildcards: *, >.
2. Bumped requests version from 2.24.0 -> 2.31.0 due to [critical vulnerability](https://security.snyk.io/package/pip/requests/2.24.0)
3. Added ability to pip install panini[tracing]. If extra package is not provided (pip install panini, installs default version with minimum requirements. If provided (pip install panini[tracing]), installs additional requirements for tracing to be enabled.
4. Forced exit if tracing middleware is used but no requirements are met
5. Bumped PyYAML dependency from 5.4 -> 6.0.1 because of new Cython version release (which breaks PyYAML build)
6. Added check when adding middlewares if tracing middleware is first in order.