### PR TITLE
bump nats-py version to 2.6.0. All tests are passing

### DIFF
--- a/requirements/defaults.txt
+++ b/requirements/defaults.txt
@@ -3,7 +3,7 @@ aiohttp-cors==0.7.0
 async-timeout==4.0.0
 requests==2.31.0
 six==1.16.0
-nats-py==2.0.0
+nats-py==2.6.0
 nats-python==0.8.0
 nest-asyncio==1.5.1
 pytest==6.2.5

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     ],
     install_requires=[
         "async-timeout==4.0.0",
-        "nats-py==2.4.0",
+        "nats-py==2.6.0",
         "websocket-client>=1.2.3",
         "requests>=2.31.0",
         "six>=1.15.0",


### PR DESCRIPTION
addressing https://github.com/lwinterface/panini/issues/282